### PR TITLE
fix: 输入法注册采用 OnDemand conf 模式，对齐 fcitx5 官方做法

### DIFF
--- a/data/inputmethod/voiceinput.conf
+++ b/data/inputmethod/voiceinput.conf
@@ -1,15 +1,7 @@
 [InputMethod]
-Name[ca]=VoiceInput
-Name[da]=VoiceInput
-Name[de]=VoiceInput
-Name[fr]=VoiceInput
-Name[he]=VoiceInput
-Name[ka]=VoiceInput
-Name[ko]=VoiceInput
-Name[ru]=VoiceInput
+Name=VoiceInput
 Name[zh_CN]=语音
 Name[zh_TW]=語音
-Name=VoiceInput
 Icon=fcitx_voiceinput
 Label=音
 LangCode=zh_CN

--- a/src/addon/voiceinput.conf.in
+++ b/src/addon/voiceinput.conf.in
@@ -5,6 +5,7 @@ GeneralName[zh_CN]=语音输入
 Comment=Fcitx5 voice input addon with ASR via OpenAI-compatible API
 Comment[zh_CN]=通过 OpenAI 兼容 API 实现的语音输入
 Category=InputMethod
+OnDemand=True
 Configurable=True
 Type=SharedLibrary
 Library=voice-input-addon


### PR DESCRIPTION
## 问题

PR #6 添加了 inputmethod conf 和图标，但存在以下问题：

1. **双重注册冲突**：addon conf 缺少 `OnDemand=True`，导致 conf 文件 + C++ `listInputMethods()` 同时生效
2. **假的本地化**：conf 中 8 个 locale（ca/da/de/fr/he/ka/ko/ru）全部设为 "VoiceInput"，与默认值完全相同，纯属噪声
3. **偏离官方模式**：fcitx5-chinese-addons (pinyin) 和 fcitx5-mozc 都用 `OnDemand=True`

## 修复

### `src/addon/voiceinput.conf.in`
```diff
+OnDemand=True
```
启用 OnDemand 后，fcitx5 不再调用 `listInputMethods()`，输入法元数据完全由 conf 文件管理。

### `data/inputmethod/voiceinput.conf`
```diff
-Name[ca]=VoiceInput   ← 无意义（=默认）
-Name[da]=VoiceInput
-Name[de]=VoiceInput
-Name[fr]=VoiceInput
-Name[he]=VoiceInput
-Name[ka]=VoiceInput
-Name[ko]=VoiceInput
-Name[ru]=VoiceInput
 Name[zh_CN]=语音
 Name[zh_TW]=語音
 Name=VoiceInput
```

## 对标

| 项目 | OnDemand | conf 文件 | listInputMethods |
|------|----------|-----------|-----------------|
| fcitx5-chinese-addons (pinyin) | ✅ | ✅ | ❌（不需要） |
| fcitx5-mozc | ✅ | ✅ | ❌（已移除） |
| **voice-input (修复后)** | ✅ | ✅ | 保留（OnDemand 下不被调用） |

## 验证

- ✅ cmake configure 通过
- ✅ cmake --build 通过