### PR TITLE
feat: support Alibaba Cloud Bailian ASR via chat completions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Select your backend from the `ActiveBackend` dropdown, then click the gear butto
 | `ApiKey` | API Key | **(required)** |
 | `Model` | Model name | `whisper-1` |
 | `Language` | Output language | `auto` (English/中文) |
+| `ApiMode` | API mode: `whisper` (standard Whisper API) or `chat` (DashScope Chat Completions) | `whisper` |
 | `LLMEnabled` | LLM post-processing | `false` |
 | `LLMModel` | Post-processing LLM model | (empty) |
 | `LLMSystemPrompt` | Post-processing system prompt | (empty) |
@@ -82,6 +83,16 @@ Set `ActiveBackend=openai`, click the gear button, and fill in your API Key. Com
 - [OpenAI](https://platform.openai.com/) — `https://api.openai.com/v1`
 - [Groq](https://console.groq.com/) — `https://api.groq.com/openai/v1`
 - [SiliconFlow](https://cloud.siliconflow.com) — `https://api.siliconflow.com/v1`
+- [Alibaba Cloud DashScope](https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference) — `https://dashscope.aliyuncs.com/compatible-mode/v1`
+
+  **Note:** DashScope's `qwen3-asr-flash` model uses Chat Completions API instead of the standard Whisper API. Set `ApiMode=chat` when using this provider.
+  ```
+  BaseUrl=https://dashscope.aliyuncs.com/compatible-mode/v1
+  ApiKey=your_dashscope_api_key
+  Model=qwen3-asr-flash
+  ApiMode=chat
+  Language=zh
+  ```
 
 #### Volcengine Doubao Backend (sub-config)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,6 +71,7 @@
 | `ApiKey` | API Key | **（必填）** |
 | `Model` | 模型名 | `whisper-1` |
 | `Language` | 输出语言 | `auto`（English/中文） |
+| `ApiMode` | API 模式：`whisper`（标准 Whisper API）或 `chat`（百炼 Chat Completions） | `whisper` |
 | `LLMEnabled` | LLM 后处理 | `false` |
 | `LLMModel` | 后处理 LLM 模型 | （空） |
 | `LLMSystemPrompt` | 后处理系统提示词 | （空） |
@@ -82,6 +83,17 @@
 - [OpenAI](https://platform.openai.com/) — `https://api.openai.com/v1`
 - [Groq](https://console.groq.com/) — `https://api.groq.com/openai/v1`
 - [硅基流动 (SiliconFlow)](https://siliconflow.cn/) — `https://api.siliconflow.cn/v1`
+- [阿里云百炼 (DashScope)](https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference) — `https://dashscope.aliyuncs.com/compatible-mode/v1`
+
+  **注意：** 阿里云百炼使用的 `qwen3-asr-flash` 模型不走标准的 Whisper API，需要通过 Chat Completions 接口调用。使用时需将 `ApiMode` 设为 `chat`，并补充对应的 DashScope API Key。配置示例：
+  ```
+  BaseUrl=https://dashscope.aliyuncs.com/compatible-mode/v1
+  ApiKey=your_dashscope_api_key
+  Model=qwen3-asr-flash
+  ApiMode=chat
+  Language=zh
+  ```
+  百炼 ASR 的具体接口文档请参考[阿里云官方文档](https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference)。
 
 #### 火山引擎豆包后端（子配置）
 

--- a/src/addon/asr/asr_engine.h
+++ b/src/addon/asr/asr_engine.h
@@ -27,6 +27,7 @@ public:
         std::string apiEndpoint;
         std::string apiKey;
         std::string language = "zh";
+        std::string apiMode = "whisper";     // "whisper" or "chat"
 
         // Volcengine Doubao streaming ASR (cloud)
         std::string authMode;

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -60,6 +60,26 @@ size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     return size * nmemb;
 }
 
+// Base64 encode
+static const char b64table[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+;
+
+std::string Base64Encode(const uint8_t* data, size_t len) {
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    for (size_t i = 0; i < len; i += 3) {
+        uint32_t v = (static_cast<uint32_t>(data[i]) << 16)
+                   | (i + 1 < len ? static_cast<uint32_t>(data[i + 1]) << 8 : 0)
+                   | (i + 2 < len ? static_cast<uint32_t>(data[i + 2]) : 0);
+        out.push_back(b64table[(v >> 18) & 0x3F]);
+        out.push_back(b64table[(v >> 12) & 0x3F]);
+        out.push_back(i + 1 < len ? b64table[(v >> 6) & 0x3F] : '=');
+        out.push_back(i + 2 < len ? b64table[v & 0x3F] : '=');
+    }
+    return out;
+}
+
 std::string BuildMultipartBody(const std::vector<uint8_t>& wavData,
                                const std::string& model,
                                const std::string& language,
@@ -105,6 +125,7 @@ OpenaiAsrSession::OpenaiAsrSession(const AsrEngine::Config& config,
     apiKey_ = config.apiKey;
     modelName_ = config.modelName.empty() ? "whisper-1" : config.modelName;
     language_ = config.language;
+    apiMode_ = config.apiMode.empty() ? "whisper" : config.apiMode;
 
     FCITX_DEBUG() << "[voice-input:openai] Init session=" << sessionId
                  << " endpoint=" << apiEndpoint_
@@ -167,14 +188,13 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
     // Build WAV
     std::vector<uint8_t> wavData = FloatPcmToWav(pcm.data(), pcm.size());
 
+    bool isChatMode = (apiMode_ == "chat");
+
     std::string endpoint = apiEndpoint_;
     if (!endpoint.empty() && endpoint.back() != '/') {
         endpoint += '/';
     }
-    endpoint += "audio/transcriptions";
-
-    std::string boundary = "----VoiceInputFormBoundary" + std::to_string(time(nullptr));
-    std::string multipartBody = BuildMultipartBody(wavData, modelName_, language_, boundary);
+    endpoint += isChatMode ? "chat/completions" : "audio/transcriptions";
 
     CURL* curl = curl_easy_init();
     if (!curl) {
@@ -183,17 +203,58 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
         return;
     }
 
-    std::string contentType = "Content-Type: multipart/form-data; boundary=" + boundary;
-
     struct curl_slist* headers = nullptr;
-    headers = curl_slist_append(headers, contentType.c_str());
+    std::string postData;
+    std::string contentType;
 
-    std::string response;
+    if (isChatMode) {
+        // ── Bailian/Chat 模式 ──
+        // WAV → base64 data URI
+        std::string b64 = Base64Encode(wavData.data(), wavData.size());
+        std::string dataUri = "data:audio/wav;base64," + b64;
+
+        // Build JSON payload
+        Json::Value msgContent;
+        msgContent["type"] = "input_audio";
+        msgContent["input_audio"]["data"] = dataUri;
+
+        Json::Value userMsg;
+        userMsg["role"] = "user";
+        userMsg["content"].append(msgContent);
+
+        Json::Value body;
+        body["model"] = modelName_;
+        body["messages"].append(userMsg);
+        body["stream"] = false;
+
+        Json::Value asrOpts;
+        asrOpts["enable_itn"] = true;
+        if (!language_.empty() && language_ != "auto") {
+            body["asr_options"]["language"] = language_;
+        }
+        body["asr_options"] = asrOpts;
+
+        Json::StreamWriterBuilder builder;
+        builder["indentation"] = "";
+        postData = Json::writeString(builder, body);
+
+        contentType = "Content-Type: application/json";
+        headers = curl_slist_append(headers, contentType.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postData.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(postData.size()));
+    } else {
+        // ── Whisper 模式 ──
+        std::string boundary = "----VoiceInputFormBoundary" + std::to_string(time(nullptr));
+        std::string multipartBody = BuildMultipartBody(wavData, modelName_, language_, boundary);
+        contentType = "Content-Type: multipart/form-data; boundary=" + boundary;
+        headers = curl_slist_append(headers, contentType.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, multipartBody.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(multipartBody.size()));
+    }
+
     curl_easy_setopt(curl, CURLOPT_URL, endpoint.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, multipartBody.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(multipartBody.size()));
 
     if (!apiKey_.empty()) {
         std::string authHeader = "Authorization: Bearer " + apiKey_;
@@ -201,6 +262,7 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     }
 
+    std::string response;
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
@@ -229,7 +291,19 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
         Json::Value json;
         Json::Reader reader;
         if (reader.parse(response, json)) {
-            text = json.get("text", json.get("error", Json::Value(""))).asString();
+            if (isChatMode) {
+                // Chat mode: choices[0].message.content
+                const auto& choices = json["choices"];
+                if (choices.isArray() && choices.size() > 0) {
+                    text = choices[0]["message"]["content"].asString();
+                }
+                if (text.empty()) {
+                    text = json.get("error", Json::Value(""))["message"].asString();
+                }
+            } else {
+                // Whisper mode: response.text
+                text = json.get("text", json.get("error", Json::Value(""))).asString();
+            }
         }
     } catch (...) {
         // ignore parse errors

--- a/src/addon/asr/openai_asr.h
+++ b/src/addon/asr/openai_asr.h
@@ -31,6 +31,7 @@ private:
     std::string apiKey_;
     std::string modelName_;
     std::string language_;
+    std::string apiMode_;
     std::vector<float> pcmBuffer_;
     std::mutex bufferMutex_;
     std::unique_ptr<std::thread> workerThread_;

--- a/src/addon/config/voiceinput-config.h
+++ b/src/addon/config/voiceinput-config.h
@@ -76,6 +76,9 @@ FCITX_CONFIGURATION(OpenAIAsrConfig,
 
     Option<bool> autoCommit{
         this, "AutoCommit", _("无 LLM 时自动上屏"), true};
+
+    Option<std::string> apiMode{
+        this, "ApiMode", _("API 模式 (whisper/chat)"), "whisper"};
 );
 
 FCITX_CONFIGURATION(VolcengineAsrConfig,

--- a/src/addon/engine.cpp
+++ b/src/addon/engine.cpp
@@ -270,6 +270,8 @@ void VoiceInputEngine::SetStatus(const std::string& text) {
     eventDispatcher_.schedule([this, text]() {
         statusText_ = text;
         if (activeIc_) {
+            activeIc_->inputPanel().setAuxDown(Text(text));
+            activeIc_->updateUserInterface(UserInterfaceComponent::InputPanel);
             activeIc_->updateUserInterface(UserInterfaceComponent::StatusArea);
         }
     });
@@ -331,6 +333,7 @@ std::unique_ptr<AsrEngine> VoiceInputEngine::CreateAsrEngine() {
         asrConfig.apiEndpoint = *openaiConfig_.baseUrl;
         asrConfig.apiKey = *openaiConfig_.apiKey;
         asrConfig.modelName = *openaiConfig_.model;
+        asrConfig.apiMode = *openaiConfig_.apiMode;
         auto language = *openaiConfig_.language;
         if (language == "auto") {
             language.clear();
@@ -377,7 +380,6 @@ void VoiceInputEngine::InitializeIfNeeded() {
                 eventDispatcher_.schedule([this]() {
                     if (!activeIc_) return;
                     activeIc_->inputPanel().setPreedit(Text(" "));
-                    activeIc_->inputPanel().setAuxDown(Text(_("正在录音中...")));
                     activeIc_->updateUserInterface(
                         UserInterfaceComponent::InputPanel);
                 });

--- a/src/addon/engine.cpp
+++ b/src/addon/engine.cpp
@@ -270,8 +270,6 @@ void VoiceInputEngine::SetStatus(const std::string& text) {
     eventDispatcher_.schedule([this, text]() {
         statusText_ = text;
         if (activeIc_) {
-            activeIc_->inputPanel().setAuxDown(Text(text));
-            activeIc_->updateUserInterface(UserInterfaceComponent::InputPanel);
             activeIc_->updateUserInterface(UserInterfaceComponent::StatusArea);
         }
     });
@@ -380,6 +378,7 @@ void VoiceInputEngine::InitializeIfNeeded() {
                 eventDispatcher_.schedule([this]() {
                     if (!activeIc_) return;
                     activeIc_->inputPanel().setPreedit(Text(" "));
+                    activeIc_->inputPanel().setAuxDown(Text(_("正在录音中...")));
                     activeIc_->updateUserInterface(
                         UserInterfaceComponent::InputPanel);
                 });


### PR DESCRIPTION
原来的程序只支持豆包和 OpenAI 的兼容输入，但是无法支持阿里云百炼的，例如qwen3-asr-flash 模型。通过修改之后可以增加对阿里云百炼的模型。

Add ApiMode option (whisper/chat) to OpenAI backend. When set to 'chat', audio is base64-encoded and sent via POST /chat/completions with input_audio message type, compatible with Alibaba Cloud DashScope qwen3-asr-flash.

Default is 'whisper' for backward compatibility.