### PR TITLE
feat: OpenAI GPT-Realtime 流式实时转录支持 (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 dist/
 .nanobot/
 .codegraph/
+.worktree/
+.opencode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,11 @@ set(ADDON_SOURCES
     src/addon/vad/silero_vad.cpp
     src/addon/pipeline/pipeline.cpp
     src/addon/asr/openai_asr.cpp
+    src/addon/asr/realtime_asr.cpp
     src/addon/asr/volcengine_asr.cpp
     src/addon/asr/asr_engine.cpp
     src/addon/asr/session_reaper.cpp
+    src/addon/asr/utils/base64.cpp
     src/addon/llm/llm_client.cpp
 )
 
@@ -126,11 +128,13 @@ set(ADDON_HEADERS
     src/addon/asr/asr_session.h
     src/addon/asr/session_reaper.h
     src/addon/asr/openai_asr.h
+    src/addon/asr/realtime_asr.h
     src/addon/asr/volcengine_asr.h
     src/addon/llm/llm_client.h
     src/addon/pipeline/pipeline.h
     src/addon/utils/audio_buffer.h
     src/addon/utils/thread_safe_queue.h
+    src/addon/asr/utils/base64.h
 )
 
 # ─── Library ──────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Select your backend from the `ActiveBackend` dropdown, then click the gear butto
 | `ApiKey` | API Key | **(required)** |
 | `Model` | Model name | `whisper-1` |
 | `Language` | Output language | `auto` (English/中文) |
-| `ApiMode` | API mode: `whisper` (standard Whisper API) or `chat` (DashScope Chat Completions) | `whisper` |
+| `ApiMode` | API mode: `whisper` (standard Whisper API), `chat` (DashScope Chat Completions) or `realtime` (GPT Realtime streaming transcription) | `whisper` |
+| `CommitIntervalMs` | Periodic commit interval (ms) in realtime mode; keeps emitting partials for long speech with no pauses | `5000` |
 | `LLMEnabled` | LLM post-processing | `false` |
 | `LLMModel` | Post-processing LLM model | (empty) |
 | `LLMSystemPrompt` | Post-processing system prompt | (empty) |
@@ -105,6 +106,16 @@ Set `ActiveBackend=openai`, click the gear button, and fill in your API Key. Com
   ApiMode=chat
   Language=zh
   ```
+
+  **GPT Realtime streaming (optional):** Set `ApiMode=realtime` to transcribe incrementally (partials update the preedit live, final commits on speech end) via the OpenAI Realtime transcription session. With an OpenAI account, use `gpt-live-transcribe` (recommended, true continuous deltas) or `gpt-realtime-whisper` (compatible alternative).
+  ```
+  BaseUrl=https://api.openai.com/v1
+  ApiKey=your_openai_api_key
+  Model=gpt-live-transcribe
+  ApiMode=realtime
+  Language=zh
+  ```
+  **Note:** Realtime mode requires a WebSocket-capable endpoint, and `gpt-live-transcribe` / `gpt-realtime-whisper` need a paid-tier account (Free is not supported). Audio is sent at 24kHz (the addon automatically upsamples the captured 16kHz).
 
 #### Volcengine Doubao Backend (sub-config)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,7 +83,8 @@ makepkg -si
 | `ApiKey` | API Key | **（必填）** |
 | `Model` | 模型名 | `whisper-1` |
 | `Language` | 输出语言 | `auto`（English/中文） |
-| `ApiMode` | API 模式：`whisper`（标准 Whisper API）或 `chat`（百炼 Chat Completions） | `whisper` |
+| `ApiMode` | API 模式：`whisper`（标准 Whisper API）、`chat`（百炼 Chat Completions）或 `realtime`（GPT Realtime 流式实时转录） | `whisper` |
+| `CommitIntervalMs` | Realtime 模式下的周期性提交间隔 (ms)，长句无停顿也能持续出增量 | `5000` |
 | `LLMEnabled` | LLM 后处理 | `false` |
 | `LLMModel` | 后处理 LLM 模型 | （空） |
 | `LLMSystemPrompt` | 后处理系统提示词 | （空） |
@@ -106,6 +107,16 @@ makepkg -si
   Language=zh
   ```
   百炼 ASR 的具体接口文档请参考[阿里云官方文档](https://help.aliyun.com/zh/model-studio/qwen-asr-api-reference)。
+
+  **Realtime 流式实时转录（可选）：** 将 `ApiMode` 设为 `realtime`，即可通过 OpenAI Realtime 转录会话实现**边说边出**增量识别结果（实时刷入候选框 preedit，说话结束提交上屏）。使用 OpenAI 官方账号时，模型推荐 `gpt-live-transcribe`（官方推荐，真正连续增量）或 `gpt-realtime-whisper`（兼容备选）。配置示例：
+  ```
+  BaseUrl=https://api.openai.com/v1
+  ApiKey=your_openai_api_key
+  Model=gpt-live-transcribe
+  ApiMode=realtime
+  Language=zh
+  ```
+  **注意：** Realtime 模式需要支持 WebSocket 的连接端点，且 `gpt-live-transcribe` / `gpt-realtime-whisper` 需付费 Tier 账号（Free 不支持）。音频以 24kHz 发送（插件会自动将采集的 16kHz 重采样到 24kHz）。
 
 #### 火山引擎豆包后端（子配置）
 

--- a/docs/adr/2026-08-07-gpt-realtime-asr.md
+++ b/docs/adr/2026-08-07-gpt-realtime-asr.md
@@ -1,0 +1,60 @@
+# ADR-2026-08-07：OpenAI GPT-Realtime 流式实时转录
+
+> 状态：已接受
+> 日期：2026-08-07
+> 决策方：@architect
+> 关联：Issue #10；技术方案 `docs/dev/specs/gpt-realtime-asr.md`
+
+## 背景
+
+用户通过 GitHub Issue #10 建议为 OpenAI 后端增加 GPT-Realtime-Whisper 流式实时转录。现状是 whisper-1 HTTP multipart 一次性转录（延迟秒级、无增量）。目标是「边说边出」增量 preedit。
+
+## 决策
+
+### D1：选 `gpt-live-transcribe` 作为默认推荐模型
+- 官方当前新接入推荐模型即 `gpt-live-transcribe`；`gpt-realtime-whisper` 列为「现有集成可继续使用」。
+- 二者同价（$0.017/音频分钟）、同 GA；`gpt-live-transcribe` 提供真连续 delta，`gpt-realtime-whisper` 需手动 commit 且 delta 可能批量到达。
+- 本插件核心诉求是实时增量，选体验更佳者无额外成本。
+- **备选**：`gpt-realtime-whisper` 保留为配置可选，兼容已用该模型的用户。
+
+### D2：零新依赖（复用 libcurl 7.86+ 内置 WebSocket）
+- Realtime 增量转录必须持久 WebSocket 连接。
+- libcurl ≥ 7.86.0 原生支持 WS（`curl_ws_send/recv` + `CURLOPT_CONNECT_ONLY=2L`），CMake 已强制要求 curl ≥ 7.86（为 Volcengine WS 而设）。
+- 不引入 websocketpp / uWebSockets 等新库；打包依赖（AUR/CPack）不变。
+- 备选（引入第三方 WS 库）被否决：多一个 C++ 依赖、维护成本高、无必要。
+
+### D3：新增独立 `RealtimeAsrEngine/RealtimeAsrSession` 类，而非改造 openai_asr
+- 现有 `OpenaiAsrSession` 是「一次性上传、End 才起线程」的批处理模型；Realtime 是「StartWorker 即建持久 WS 会话、持续收发、手动 commit」的流式模型。
+- 并入 openai_asr 会使该文件有 whisper/chat/realtime 三个互不相关的修改理由，违反 SRP。
+- 与项目既有模式一致：`volcengine_asr` 已是独立 WS 流式引擎类，Realtime 复用其线程模型。
+
+### D4：16k→24k 线性上采样（放引擎内部）
+- Realtime API 硬性要求 pcm16/mono/24kHz，16k 会被拒。
+- 只在 realtime 路径需要，放引擎内部隔离，不污染共享音频路径与 VAD（VAD 仍用 16k）。
+- 比例固定 3/2，线性插值即可，不引入重采样库。
+
+### D5：commit 时机 = VAD 静音（主） + 周期性兜底（次）
+- 主提交点：Silero VAD 语音结束（`SpeechEventType::End`）→ `End()` → 发 `input_audio_buffer.commit` → 收 `.completed` final。
+- 兜底：worker 周期性 commit（`commitIntervalMs`，默认 5s），解决长句无停顿拿不到增量的问题（对 `gpt-realtime-whisper` 尤其必要；对 `gpt-live-transcribe` 是纯增量刷新）。
+- 架构上自然契合现有 VAD 状态机（调研 §5.3 亦指出此契合点）。
+
+### D6：复用配置段与 apiMode 分流，不新增引擎配置结构
+- 复用 `OpenAIAsrConfig`（baseUrl/apiKey/model/language/apiMode），仅 `ApiModeAnnotation` 增 `"realtime"` 枚举 + 新增 `commitIntervalMs`。
+- 通过配置即插即用，不改配置结构、不动其他引擎。
+
+## 权衡 / 被否决的替代方案
+| 方案 | 否决理由 |
+|------|---------|
+| 改造现有 openai_asr 加 realtime 分支 | 违背 SRP；批处理与流式模型差异大 |
+| 引入第三方 WS 库（websocketpp 等） | 零新依赖可行（curl 已内置 WS），多依赖徒增维护成本 |
+| 默认 `gpt-realtime-whisper` | 官方非新接入推荐、增量体验差；`gpt-live-transcribe` 同价更优 |
+| 纯 HTTP/SSE 流式替代 | 无纯 HTTP 实时增量方案（调研 C4），得不到持续增量 |
+
+## 后果
+- 现有 whisper-1 / chat / Volcengine 路径零改动，可回滚。
+- 新增实时转录能力，通过 `apiMode="realtime"` 启用。
+- 遗留风险：增量逐词实时程度（A1，置信度中-高）需最小原型实测确认；周期 commit 兜底保证可用性，不阻塞交付。
+
+## 影响文件
+- 新增：`src/addon/asr/realtime_asr.{h,cpp}`
+- 修改：`voiceinput-config.h`、`engine.cpp`、`CMakeLists.txt`、`openai_asr.cpp`（Base64Encode 提升复用）

--- a/docs/dev/specs/gpt-realtime-asr.md
+++ b/docs/dev/specs/gpt-realtime-asr.md
@@ -1,0 +1,228 @@
+# 技术方案：OpenAI GPT-Realtime 流式实时转录
+
+> 面向 fcitx5-voice-input（C++ Fcitx5 语音输入插件）。为 OpenAI 后端增加 GPT-Realtime 流式实时转录（边说边出增量 preedit），作为现有 whisper-1 HTTP 一次性转录之外的实时方案。
+> 日期：2026-08-07。作者：@architect。
+> 前置调研：`docs/dev/research/gpt-realtime-whisper.md`。
+
+---
+
+## 1. 目标与范围
+
+### 1.1 目标
+在 OpenAI 后端下，新增一种「实时转录」API 模式：通过 WebSocket 持久会话把采集到的 PCM 音频持续推送到 OpenAI Realtime 转录端点，**边说边出**增量文本（通过 `isPartial` 实时刷入 preedit），语音段结束后提交最终结果上屏。
+
+### 1.2 范围
+- **包含**：新 AsrEngine/AsrSession 实现、16k→24k 重采样、WS 客户端线程、commit 时机、断线重连、配置项、工厂接入。
+- **不包含**（YAGNI）：翻译会话、WebRTC、多语种检测（`gpt-transcribe`）、本地 ASR 改造、LLM 后处理在实时路径的特殊优化（沿用现有通道）。
+
+### 1.3 非目标（明确排除）
+- 不改变现有 whisper-1 / chat 模式与 Volcengine 引擎的行为。
+- 不引入任何新依赖库（复用 libcurl 7.86+ 内置 WebSocket）。
+- 不做 HTTP/SSE 流式替代（Realtime 增量必须持久 WS 连接，调研 C4）。
+
+---
+
+## 2. 架构决策
+
+### 2.1 新引擎类 vs 改造现有 openai_asr —— **新增独立引擎类**
+
+推荐：**新增 `RealtimeAsrEngine` / `RealtimeAsrSession`（新文件 `realtime_asr.cpp/.h`）**，而非在 `openai_asr.cpp` 里继续塞分支。
+
+理由（SRP）：
+- 现有 `OpenaiAsrSession` 是「一次性上传、End 时才起 worker 线程」的批处理模型；Realtime 是「StartWorker 即建持久 WS 会话、持续收发、手动 commit」的流式模型。两者 worker 生命周期、commit 语义、断线重连逻辑完全不同。
+- 若并入 openai_asr.cpp，该文件会有「whisper 批量」「chat」与「realtime 流式」三个互不相关的修改理由，违反 SRP。
+- 与项目既有模式一致：`volcengine_asr.cpp/.h` 已是独立引擎类，同样走 WS 流式。Realtime 与其架构高度相似，独立成类可完全复用其模式。
+
+接入方式（保持配置段复用）：`CreateAsrEngine()` 的 OpenAI 分支中，按 `apiMode` 分流——`apiMode == "realtime"` 时创建 `RealtimeAsrEngine`，否则创建现有 `OpenaiAsrEngine`。**复用 `OpenAIAsrConfig` 配置段**（baseUrl/apiKey/model/language/apiMode），不改配置结构、不动其他引擎。
+
+```cpp
+// engine.cpp CreateAsrEngine() openai 分支
+auto apiMode = *openaiConfig_.apiMode;
+asrConfig.apiMode = apiMode;
+if (apiMode == "realtime") {
+    asr = std::make_unique<RealtimeAsrEngine>();
+} else {
+    asr = std::make_unique<OpenaiAsrEngine>();
+}
+```
+
+### 2.2 重采样 16k→24k —— 线性上采样，放引擎内部
+
+**位置**：`RealtimeAsrSession` worker 线程内，发送 base64 之前（16k float → 24k int16 → base64）。
+
+理由：
+- Realtime API 硬性要求 pcm16/mono/**24kHz**，16k 会被拒（调研 C6）。本项目采集统一 16kHz。
+- 只在 realtime 路径需要，whisper/chat/volcengine 均保持 16k 不动。放引擎内部隔离影响，**不污染共享的 pipeline 音频路径**与 VAD（VAD 仍用 16k）。
+- 上采样比例固定 1.5×（24k/16k=3/2），**线性插值**足够（每 2 个源样本线性插出 3 个目标样本），CPU 开销可忽略，符合 KISS。无需引入重采样库。
+
+实现要点：
+- `FeedAudio` 收到 float（16k），与现状一样经队列送 worker；worker 内做 `float(16k) → float(24k) 线性插值 → int16 → Base64Encode`。
+- 复用 `openai_asr.cpp` 已存在的 `Base64Encode`（提升到公共位置或独立小工具，见 4.4）。
+
+### 2.3 WS 客户端线程模型 —— 完全复用 volcengine 模式
+
+`RealtimeAsrSession` 生命周期与 `VolcengineAsrSession` 完全对齐：
+
+| 阶段 | 行为 |
+|------|------|
+| `StartSession()` | 分配 sessionId，创建 session，`StartWorker()` 立即启动 worker 线程（**与 whisper 不同：建会话即连 WS**） |
+| `StartWorker()` | worker 线程：`curl_easy_init` + `CURLOPT_CONNECT_ONLY=2L` + `curl_easy_perform` 完成 WS Upgrade → `curl_ws_send/recv` 持续收发 |
+| `FeedAudio()` | 转 int16 推入 `audioChunks_` 队列 |
+| `End()` | 置 finished，发 `input_audio_buffer.commit`，收 `.completed`，关连接退出 |
+| `Cancel()` | 置 cancelled，关连接退出 |
+| 会话结束 | pipeline 把 `shared_ptr` 交给 `SessionReaper` 后台清理（与 volcengine 一致） |
+
+**与 pipeline/SessionReaper 衔接**：
+- pipeline 只感知一个 `AsrSession`，`activeSessionId_`/`sessionGenerationMap_` 逻辑零改动。
+- **重连不改变 session 对象与 sessionId**：断线/30min 时 worker 在**自身循环内**重建底层 WS 连接，`AsrSession::State::sessionId` 保持不变 → `resultCb_(text, isFinal, sid)` 的 sid 稳定，pipeline 无需感知重连。
+- 结果回调走现有 `resultCb_`，`SessionReaper` 负责 join/清理（防 worker 泄漏）。
+
+线程安全：`audioChunks_` 用现有 `ThreadSafeQueue<std::vector<int16_t>>`；`state_` 用 `AsrSession::State` 的 atomic `cancelled/finished`。与 volcengine 完全一致，无新增同步原语。
+
+### 2.4 实时中间结果经 isPartial 到 preedit —— 现有链路零改动
+
+pipeline 的 `SetAsrEngine` 回调已内置完整分发逻辑：
+
+```
+RealtimeAsrSession.resultCb_(delta, false, sid)        // isFinal=false
+  → Pipeline SetAsrEngine lambda → AsrResult{isPartial=true}
+  → resultQueue_ → engine::PollResults()
+  → inputPanel().setPreedit(Text(result.text))         // 实时刷入 preedit
+```
+
+- delta 在引擎内**按 item/会话累加**为当前累计文本，非空时回调 `isFinal=false`。
+- final：`.completed` 回调 `isFinal=true` → 走现有 final 分支（`autoCommit` → commitString，或 LLM 后处理 / 预编辑待确认）。
+- **pipeline / engine 的分发代码无需修改**（`isPartial` 字段与 preedit 分支已存在并验证）。
+
+### 2.5 commit 时机策略 —— VAD 静音触发 + 周期性兜底
+
+**主提交时机（VAD 静音）**：Silero VAD 检测到语音结束（`SpeechEventType::End`）→ pipeline 调 `activeSession_->End()` → 引擎发 `input_audio_buffer.commit` → 收 `.completed`（final）。这是「语音输入法」的语义主点：一次说话结束即提交上屏。
+
+**周期性兜底（长句无停顿）**：
+- 对 `gpt-live-transcribe`（支持真连续 delta），worker 循环中**无需 commit 也能持续收到 delta**，实时增量天然满足。
+- 对 `gpt-realtime-whisper`（无 server_vad、需手动 commit 才出结果），长句不中断则拿不到增量。因此 worker 内置**周期性 commit 兜底**（如每 5s 发一次 `input_audio_buffer.commit`），保证长句也能持续出结果；代价是切分语义（词准确率略降），作为可调项。
+
+**实现**：worker 发送循环里记录「距上次 commit 的时长」，超过 `commitIntervalMs`（配置，默认 5000ms）且当前有累积音频时自动 commit；VAD End 的 commit 覆盖最终段。对 live-transcribe 可将兜底视为纯增量刷新。
+
+### 2.6 配置项设计 —— 复用 apiMode，新增枚举值
+
+| 配置键（现有 `OpenAIAsrConfig`） | 变更 |
+|------|------|
+| `apiMode` | 新增枚举值 `"realtime"`（`ApiModeAnnotation` 增加 Enum/2），触发 Realtime 引擎 |
+| `model` | 复用；填 `gpt-live-transcribe`（推荐）或 `gpt-realtime-whisper` |
+| `baseUrl` | 复用；WS 端点由 baseUrl 派生：`https://`→`wss://` 后拼 `/v1/realtime?model=<model>` |
+| `apiKey` | 复用（`Authorization: Bearer`） |
+| `language` | 复用（`session.update` 的 `transcription.language` hint） |
+| 新增 | `commitIntervalMs`（周期性兜底 commit 间隔，默认 5000，IntConstrain 1000~30000） |
+
+**WS 端点派生**：`baseUrl` 是 `https://api.openai.com/v1` → 替换 scheme 为 `wss://` 得到 `wss://api.openai.com/v1`，拼 `/realtime?model=<model>`。若用户填的 baseUrl 已是 `wss://`（自建兼容端点）则直接用。**不引入新配置键存放端点**（KISS）。
+
+### 2.7 断线重连、30min 会话、错误处理
+
+- **断线重连**：worker 主循环内，若 `curl_ws_recv` 返回连接关闭/错误，且 `state_->cancelled` 为 false 且未 End，则等待退避（如 1s）后**重建 WS 连接**（保持同一 session/sessionId），从当前音频缓冲区续推。
+- **30min 会话上限**：worker 内计时，到点强制 commit 一次并重建连接（同一 sessionId）。官方约 ≤30min 上限（调研 §3.3/§5.3）。
+- **错误处理**：
+  - 连接失败/鉴权失败 → `errorCb_` 记日志；对活动说话段回调 `resultCb_("", true, sid)`（空 final 触发 pipeline 的 error 分支，清 preedit、提示失败）。
+  - 转录失败事件（`.failed`）→ 同上。
+  - 重连失败超过 `maxReconnectAttempts`（如 3 次）→ 放弃，按错误结束会话。
+
+---
+
+## 3. 模块与文件
+
+### 3.1 新增文件
+| 文件 | 职责 |
+|------|------|
+| `src/addon/asr/realtime_asr.h` | `RealtimeAsrEngine` + `RealtimeAsrSession` 声明 |
+| `src/addon/asr/realtime_asr.cpp` | 实现：WS 连接、16k→24k 重采样、delta/completed 解析、commit/重连 |
+
+### 3.2 修改文件
+| 文件 | 改动 |
+|------|------|
+| `src/addon/asr/openai_asr.cpp` | 将 `Base64Encode` 提升为可在 realtime 复用的公共函数（或移至独立工具），自身逻辑不动 |
+| `src/addon/config/voiceinput-config.h` | `ApiModeAnnotation` 增加 `"realtime"`；`OpenAIAsrConfig` 增加 `commitIntervalMs` |
+| `src/addon/engine.cpp` | `CreateAsrEngine()` openai 分支按 `apiMode=="realtime"` 分流创建 `RealtimeAsrEngine` |
+| `CMakeLists.txt` | `ADDON_SOURCES` 增 `realtime_asr.cpp`；`ADDON_HEADERS` 增 `realtime_asr.h` |
+
+### 3.3 依赖影响 —— **零新依赖**
+- `curl >= 7.86.0` 内置 WebSocket（`curl_ws_send/recv` + `CURLOPT_CONNECT_ONLY=2L`），CMake 第 52-54 行已强制要求。
+- `jsoncpp`（事件序列化/解析）、`Base64Encode`（复用）均已有。
+- 无新 pkg-config、无新链接库、无需打包改动（AUR/CPack 依赖不变）。
+
+---
+
+## 4. 接口设计
+
+### 4.1 复用既有接口
+- `AsrEngine` / `AsrSession`（`asr_engine.h` / `asr_session.h`）：`RealtimeAsrSession` 实现 `FeedAudio/End/Cancel/JoinWithTimeout/StartWorker`，回调 `resultCb_(text, isFinal, sessionId)`。**对外接口零新增**。
+- `AsrResult.isPartial`：已存在，用于增量 preedit。
+
+### 4.2 RealtimeAsrSession 内部接口（私有）
+```cpp
+class RealtimeAsrSession : public AsrSession {
+public:
+    // 构造/析构/Override 同 VolcengineAsrSession
+private:
+    void WorkerLoop();                    // 主线程：WS 收发 + commit/重连
+    bool ConnectWebSocket(CURL** curl);   // CONNECT_ONLY + upgrade，返回是否成功
+    bool SendAppend(const std::vector<int16_t>& pcm24k); // input_audio_buffer.append
+    bool SendCommit();                    // input_audio_buffer.commit
+    void HandleServerEvent(const Json::Value& ev); // delta/completed/failed
+    void Upsample16kTo24k(const std::vector<int16_t>& in,
+                          std::vector<int16_t>& out); // 线性插值
+    std::string currentTranscript_;       // 当前 item 累计文本
+    std::string itemId_;                  // 当前 commit item
+    int commitIntervalMs_;
+    // ...
+};
+```
+
+### 4.3 WS 事件协议（来自调研 §2）
+- 客户端 → 服务端：`input_audio_buffer.append`（`{type, audio:<base64 pcm24k>}`）、`input_audio_buffer.commit`、`session.update`（`{type:"session.update", session:{transcription:{model,language}}}`，可选）。
+- 服务端 → 客户端：`conversation.item.input_audio_transcription.delta`（`item_id,delta`，isFinal=false）、`.completed`（`item_id,transcript`，isFinal=true）、`.failed`。
+- 认证：`Authorization: Bearer <key>`；GA 接口**不带** `OpenAI-Beta` 头。
+
+### 4.4 Base64 复用
+`openai_asr.cpp` 的 `Base64Encode` 当前在匿名 namespace。为供 realtime 复用，将其**提升**为 `fcitx` 命名空间内的公共自由函数（放在 `openai_asr.h` 或独立 `utils/base64.h`）。两处调用，**达到 DRY 阈值 2 次**，允许最小抽象。
+
+---
+
+## 5. 模型选型（推荐）
+
+**推荐：`gpt-live-transcribe`**（方案 C）。
+
+| 维度 | gpt-live-transcribe | gpt-realtime-whisper |
+|------|---------------------|----------------------|
+| 增量体验 | 真连续 delta，可调 `delay`（调研 §2.3） | 需手动 commit，delta 可能批量到达 |
+| 官方定位 | 当前新接入推荐模型 | 现有集成可继续使用，非新接入推荐 |
+| 计费 | $0.017/音频分钟 | $0.017/音频分钟（相同） |
+| 可用性 | GA | GA |
+
+理由：
+- 本插件核心诉求是「边说边显示增量」——`gpt-live-transcribe` 正是为此设计，能最大化实时体验。
+- 二者同价、同 GA，选体验更佳者无额外成本。
+- `gpt-realtime-whisper` 作为配置项**可选**（兼容已用该模型的用户），默认/文档推荐 `gpt-live-transcribe`。
+
+---
+
+## 6. DAG 任务拆解
+
+见 `docs/dev/tasks/gpt-realtime-asr.md`。
+
+---
+
+## 7. 假设与不确定项
+
+| # | 内容 | 影响 |
+|---|------|------|
+| A1 | `gpt-live-transcribe` 的连续 delta 在 C++ 实测中确实逐词实时（调研 C5 置信度中-高） | 若实测仍批量到达，周期 commit 兜底保证可用性；不阻塞交付 |
+| A2 | WS 端点由 baseUrl `https→wss` 派生正确 | 若用户用自建端点，需自行填对 baseUrl；提供日志便于排查 |
+| A3 | 重连保持 sessionId 不会触发 OpenAI 侧状态错乱 | 重连即全新 WS 会话，服务端无跨连接状态依赖；若出问题，周期 commit + 空 final 兜底 |
+| A4 | 免费 Tier 不可用（需付费） | 配置文档注明；连接失败走 error 分支提示 |
+| A5 | `commitIntervalMs` 默认 5000ms 是否最优 | 属调参项，默认值保守可用；通过配置暴露 |
+
+---
+
+## 8. 参考
+- 调研文档：`docs/dev/research/gpt-realtime-whisper.md`（端点、协议、模型、计费一手来源）。
+- 既有实现参考：`src/addon/asr/volcengine_asr.cpp`（WS worker 线程模型）、`src/addon/asr/openai_asr.cpp`（Base64Encode）。

--- a/docs/dev/specs/gpt-realtime-asr.md
+++ b/docs/dev/specs/gpt-realtime-asr.md
@@ -100,9 +100,13 @@ RealtimeAsrSession.resultCb_(delta, false, sid)        // isFinal=false
 
 **周期性兜底（长句无停顿）**：
 - 对 `gpt-live-transcribe`（支持真连续 delta），worker 循环中**无需 commit 也能持续收到 delta**，实时增量天然满足。
-- 对 `gpt-realtime-whisper`（无 server_vad、需手动 commit 才出结果），长句不中断则拿不到增量。因此 worker 内置**周期性 commit 兜底**（如每 5s 发一次 `input_audio_buffer.commit`），保证长句也能持续出结果；代价是切分语义（词准确率略降），作为可调项。
+- 对 `gpt-realtime-whisper`（无 server_vad、需手动 commit 才出结果），长句不中断则拿不到增量。因此 worker 内置**周期性 commit 兜底**（如每 5s 发一次 `input_audio_buffer.commit`），保证长句也能持续出结果。
 
-**实现**：worker 发送循环里记录「距上次 commit 的时长」，超过 `commitIntervalMs`（配置，默认 5000ms）且当前有累积音频时自动 commit；VAD End 的 commit 覆盖最终段。对 live-transcribe 可将兜底视为纯增量刷新。
+**pipeline 单-final 契约（实现约束）**：pipeline 的 `SetAsrEngine` 回调在收到任意 `isFinal=true` 后会 `sessionGenerationMap_.erase(sid)`，其后该会话所有结果被丢弃。因此**每个会话只能上报一次 final**：
+- **只有 VAD End 触发的 `.completed` 上报 final**（`isFinal=true`）。
+- **周期性 commit 产生的 `.completed` 一律作为增量 partial 上报**（`isFinal=false`，仅刷新 preedit，不上屏）。这是审查（2026-08-07）修正的关键点，避免首个周期 commit 后后续结果全被丢弃。
+
+**实现**：worker 发送循环里记录「距上次 commit 的时长」，超过 `commitIntervalMs`（配置，默认 5000ms）且当前有累积音频时自动 commit；`.completed` 事件到达时按 `state_->finished` 判断：已 End → final，否则 → partial。对 live-transcribe 可将兜底视为纯增量刷新。
 
 ### 2.6 配置项设计 —— 复用 apiMode，新增枚举值
 

--- a/docs/dev/tasks/gpt-realtime-asr.md
+++ b/docs/dev/tasks/gpt-realtime-asr.md
@@ -1,0 +1,132 @@
+# DAG 任务拆解：OpenAI GPT-Realtime 流式实时转录
+
+> 依据技术方案 `docs/dev/specs/gpt-realtime-asr.md` 与 ADR `docs/adr/2026-08-07-gpt-realtime-asr.md`。
+> 每个任务为垂直切片、单人 2-4 小时可完成；标注依赖关系。
+
+## 依赖图总览
+
+```
+T1 (Base64 提升复用)
+    │
+    ├─→ T2 (realtime_asr 骨架 + 重采样) ──→ T3 (WS 传输 + 事件解析)
+    │                                          │
+    ├─→ T4 (commit 时机 + 重连) ───────────────┘
+    │
+    ├─→ T5 (配置项: apiMode + commitIntervalMs)
+    │       │
+    │       ├─→ T6 (engine.cpp 工厂分流)
+    │       │
+    │       └─→ T7 (CMake 接入)
+    │
+    └─→ T8 (构建验证 + 文档收尾)
+```
+
+**串行关键路径**：T1 → T2 → T3 → T4 → T6 → T8
+**可并行**：T5 可与 T2/T3 并行；T7 可与 T6 并行。
+
+---
+
+## T1: 提升 Base64Encode 为公共函数
+
+- **目标**：使 `RealtimeAsrSession` 能复用现有 `Base64Encode`（DRY）。
+- **改动文件**：
+  - `src/addon/asr/openai_asr.cpp`：将匿名 namespace 的 `Base64Encode` 提升为 `fcitx` 命名空间内公共函数。
+  - 新增 `src/addon/asr/utils/base64.h`（声明）+ `.cpp`（实现）或放在 `openai_asr.h` 声明。
+- **依赖**：无。
+- **验证**：`OpenaiAsrSession` 的 whisper 路径编译通过、行为不变（回归）；新函数可被单独调用。
+
+---
+
+## T2: RealtimeAsrSession 骨架 + 16k→24k 重采样
+
+- **目标**：新建 `RealtimeAsrEngine`/`RealtimeAsrSession` 类骨架，实现 `AsrSession` 全部虚函数；worker 线程 + `FeedAudio` 队列 + 16k→24k 线性插值。
+- **改动文件**：
+  - 新增 `src/addon/asr/realtime_asr.h`
+  - 新增 `src/addon/asr/realtime_asr.cpp`
+- **依赖**：T1（复用 Base64Encode）。
+- **实现要点**：
+  - 类结构仿照 `VolcengineAsrSession`：`audioChunks_`（`ThreadSafeQueue<std::vector<int16_t>>`）、`workerThread_`、atomic `state_`。
+  - `FeedAudio` 转 int16 入队；`StartWorker` 启动线程；`End/Cancel/JoinWithTimeout` 对齐 volcengine。
+  - `Upsample16kTo24k()`：线性插值，比例 3/2。
+- **验证**：构造 session、FeedAudio、End 后 worker 能消费队列并打印重采样样本数（先用日志桩验证，WS 在 T3 接入）。
+
+---
+
+## T3: WS 传输 + 事件解析
+
+- **目标**：worker 内建 WS 连接（`CURLOPT_CONNECT_ONLY=2L` + `curl_ws_send/recv`），推送 `input_audio_buffer.append`，解析 `delta/completed/failed` 并经 `resultCb_` 回调。
+- **改动文件**：`src/addon/asr/realtime_asr.cpp`
+- **依赖**：T2。
+- **实现要点**：
+  - 端点：`baseUrl` https→wss 派生 + `/v1/realtime?model=<model>`；`Authorization: Bearer` 头；GA 不带 OpenAI-Beta 头。
+  - `session.update` 可选项：设 `transcription.language`。
+  - `delta` → 累加到 `currentTranscript_`，`resultCb_(text, false, sid)`；`completed` → `resultCb_(transcript, true, sid)`。
+  - `SendAppend`：16k→24k→int16→Base64 封 JSON 发送。
+- **验证**：连接真实（若有 key 可端到端）；无 key 时验证 JSON 构造与发送路径正确、错误分支走 `errorCb_`。
+
+---
+
+## T4: commit 时机 + 断线重连 + 30min 会话
+
+- **目标**：实现「VAD End → commit」主提交 + 周期性 commit 兜底；断线/30min 重连（保持 sessionId）。
+- **改动文件**：`src/addon/asr/realtime_asr.cpp`
+- **依赖**：T3。
+- **实现要点**：
+  - `End()` → `SendCommit()` → 收 `.completed` final。
+  - worker 记录距上次 commit 时长，超 `commitIntervalMs` 自动 commit（长句兜底）。
+  - `curl_ws_recv` 断开/错误且未取消 → 退避（1s）重建 WS 连接，同 sessionId；超 `maxReconnectAttempts`（3）放弃走 error。
+  - 30min 计时强制 commit + 重连。
+- **验证**：模拟连接断开（断网/关服务）→ 观察重连日志与续推；长句测试周期性 commit 出增量。
+
+---
+
+## T5: 配置项（apiMode="realtime" + commitIntervalMs）
+
+- **目标**：`ApiModeAnnotation` 增加 `"realtime"` 枚举；`OpenAIAsrConfig` 增加 `commitIntervalMs`。
+- **改动文件**：`src/addon/config/voiceinput-config.h`
+- **依赖**：无（可与 T2 并行）。
+- **验证**：配置 dump 生成正确；值经 `Config::apiMode`/`commitIntervalMs` 读取无误。
+
+---
+
+## T6: engine.cpp 工厂分流
+
+- **目标**：`CreateAsrEngine()` openai 分支按 `apiMode=="realtime"` 创建 `RealtimeAsrEngine`。
+- **改动文件**：`src/addon/engine.cpp`
+- **依赖**：T5（配置项）、T2（引擎类存在）。
+- **验证**：配置 `apiMode=realtime` 时 `asr->Name()=="realtime"`；`apiMode=whisper` 时仍为 `openai-compat`（回归）。
+
+---
+
+## T7: CMake 接入
+
+- **目标**：将 `realtime_asr.cpp`/`.h` 加入 `ADDON_SOURCES`/`ADDON_HEADERS`。
+- **改动文件**：`CMakeLists.txt`
+- **依赖**：T2（文件存在）。
+- **验证**：`cmake --build` 通过，链接无缺符号。
+
+---
+
+## T8: 构建验证 + 文档收尾
+
+- **目标**：全量编译 + 回归现有后端 + 更新 README/配置文档说明实时模式。
+- **改动文件**：`README.md`（或配置说明文档）、`po/zh_CN.po`（新增字符串 `commitIntervalMs` 等，如需）
+- **依赖**：T6、T7。
+- **验证**：`cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j` 通过；配置 UI 显示新枚举与选项；三种 apiMode 均编译通过。
+
+---
+
+## 任务属性汇总
+
+| 任务 | 文件数 | 新增文件 | 修改文件 | 依赖 | 预估 |
+|------|--------|----------|----------|------|------|
+| T1 | 2 | utils/base64 或复用头 | openai_asr.cpp | — | 0.5h |
+| T2 | 2 | realtime_asr.h/.cpp | — | T1 | 2h |
+| T3 | 1 | — | realtime_asr.cpp | T2 | 3h |
+| T4 | 1 | — | realtime_asr.cpp | T3 | 2h |
+| T5 | 1 | — | voiceinput-config.h | — | 0.5h |
+| T6 | 1 | — | engine.cpp | T5, T2 | 0.5h |
+| T7 | 1 | — | CMakeLists.txt | T2 | 0.2h |
+| T8 | 2-3 | — | README/po | T6, T7 | 1h |
+
+> 说明：T3/T4 集中在 `realtime_asr.cpp`，若单人实现可合并为一个提交，但拆为 T3/T4 便于独立验证 WS 传输与重连语义。总改动 ≤10 文件，可单批次交付。

--- a/src/addon/asr/asr_engine.h
+++ b/src/addon/asr/asr_engine.h
@@ -27,7 +27,10 @@ public:
         std::string apiEndpoint;
         std::string apiKey;
         std::string language = "zh";
-        std::string apiMode = "whisper";     // "whisper" or "chat"
+        std::string apiMode = "whisper";     // "whisper" or "chat" or "realtime"
+
+        // OpenAI Realtime (streaming): periodic commit interval for long speech
+        int commitIntervalMs = 5000;
 
         // Volcengine Doubao streaming ASR (cloud)
         std::string authMode;

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -12,6 +12,8 @@
 #include <fcitx-utils/log.h>
 #include <json/json.h>
 
+#include "utils/base64.h"
+
 using namespace std::chrono_literals;
 
 namespace fcitx {
@@ -60,25 +62,7 @@ size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     return size * nmemb;
 }
 
-// Base64 encode
-static const char b64table[] =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
-;
-
-std::string Base64Encode(const uint8_t* data, size_t len) {
-    std::string out;
-    out.reserve(((len + 2) / 3) * 4);
-    for (size_t i = 0; i < len; i += 3) {
-        uint32_t v = (static_cast<uint32_t>(data[i]) << 16)
-                   | (i + 1 < len ? static_cast<uint32_t>(data[i + 1]) << 8 : 0)
-                   | (i + 2 < len ? static_cast<uint32_t>(data[i + 2]) : 0);
-        out.push_back(b64table[(v >> 18) & 0x3F]);
-        out.push_back(b64table[(v >> 12) & 0x3F]);
-        out.push_back(i + 1 < len ? b64table[(v >> 6) & 0x3F] : '=');
-        out.push_back(i + 2 < len ? b64table[v & 0x3F] : '=');
-    }
-    return out;
-}
+// Base64 编码已提取到 utils/base64.h，此处复用公共实现。
 
 std::string BuildMultipartBody(const std::vector<uint8_t>& wavData,
                                const std::string& model,

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -1,0 +1,410 @@
+#include "realtime_asr.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+#include <curl/curl.h>
+#include <fcitx-utils/log.h>
+#include <json/json.h>
+
+#include "utils/base64.h"
+
+using namespace std::chrono_literals;
+
+namespace fcitx {
+namespace {
+
+constexpr int kSourceSampleRate = 16000;
+constexpr int kTargetSampleRate = 24000;  // OpenAI Realtime 要求 >= 24kHz
+constexpr int kAppendChunkSamples = 2400; // ~100ms @24k 音频推送粒度（含重采样后）
+
+enum class RecvStatus { Ok, Again, Closed, Error };
+
+// 16k float → 24k float 线性插值（比例 3/2）。每 2 个源样本插出 3 个目标样本。
+void Upsample16kTo24k(const std::vector<float>& in, std::vector<float>& out) {
+    out.clear();
+    out.reserve(in.size() * 3 / 2 + 2);
+    if (in.size() < 2) {
+        for (float s : in) out.push_back(s);
+        return;
+    }
+    for (size_t i = 0; i + 1 < in.size(); ++i) {
+        float a = in[i];
+        float b = in[i + 1];
+        out.push_back(a);                    // t=0/3
+        out.push_back(a + (b - a) * 2.0f / 3.0f); // t=2/3
+        out.push_back(a + (b - a) * 1.0f / 3.0f); // t=1/3（插值顺序交错）
+    }
+    out.push_back(in.back());
+}
+
+std::string JsonToString(const Json::Value& json) {
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    return Json::writeString(builder, json);
+}
+
+// 发送一个 TEXT WS 帧（OpenAI Realtime 用 JSON 文本帧）。
+bool SendWebSocketText(CURL* curl, const std::string& data,
+                       const std::atomic<bool>& cancelFlag) {
+    size_t remaining = data.size();
+    const char* ptr = data.data();
+    while (remaining > 0) {
+        if (cancelFlag.load()) return false;
+        size_t sent = 0;
+        CURLcode result =
+            curl_ws_send(curl, ptr, remaining, &sent, 0, CURLWS_TEXT);
+        if (result == CURLE_AGAIN) { std::this_thread::sleep_for(10ms); continue; }
+        if (result != CURLE_OK) {
+            FCITX_ERROR() << "[voice-input:realtime] curl_ws_send failed: "
+                          << curl_easy_strerror(result);
+            return false;
+        }
+        ptr += sent;
+        remaining -= sent;
+    }
+    return true;
+}
+
+// 接收一帧 TEXT，返回 JSON 字符串。跨分片拼接（bytesleft）。
+RecvStatus ReceiveTextFrame(CURL* curl, std::string& out) {
+    out.clear();
+    std::array<char, 8192> buffer{};
+    while (true) {
+        size_t received = 0;
+        const struct curl_ws_frame* meta = nullptr;
+        CURLcode result =
+            curl_ws_recv(curl, buffer.data(), buffer.size(), &received, &meta);
+        if (result == CURLE_AGAIN) return RecvStatus::Again;
+        if (result != CURLE_OK) {
+            FCITX_ERROR() << "[voice-input:realtime] curl_ws_recv failed: "
+                          << curl_easy_strerror(result);
+            return RecvStatus::Error;
+        }
+        if (meta && (meta->flags & CURLWS_CLOSE)) return RecvStatus::Closed;
+        bool isText = meta && (meta->flags & CURLWS_TEXT);
+        if (received > 0) out.append(buffer.data(), received);
+        if (!meta || !isText) continue;
+        if (meta->bytesleft == 0) return RecvStatus::Ok;
+    }
+}
+
+void CloseWebSocket(CURL* curl) {
+    if (!curl) return;
+    size_t sent = 0;
+    CURLcode res = curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
+    if (res != CURLE_OK)
+        FCITX_WARN() << "[voice-input:realtime] WS close failed: "
+                     << curl_easy_strerror(res);
+}
+
+} // namespace
+
+// ── RealtimeAsrSession ────────────────────────────────────────
+
+RealtimeAsrSession::RealtimeAsrSession(const AsrEngine::Config& config,
+                                       AsrSession::ErrorCallback errorCb,
+                                       uint64_t sessionId) {
+    state_->sessionId = sessionId;
+    errorCb_ = std::move(errorCb);
+    audioChunks_ = std::make_shared<ThreadSafeQueue<std::vector<int16_t>>>();
+
+    // 由 baseUrl（https://api.openai.com/v1）派生 wss 端点
+    std::string base = config.apiEndpoint;
+    if (!base.empty()) {
+        const std::string httpsPrefix = "https://";
+        const std::string wssPrefix = "wss://";
+        if (base.compare(0, httpsPrefix.size(), httpsPrefix) == 0)
+            base.replace(0, httpsPrefix.size(), wssPrefix);
+        if (!base.empty() && base.back() != '/') base += '/';
+    }
+    modelName_ = config.modelName.empty() ? "gpt-live-transcribe" : config.modelName;
+    endpoint_ = base + "realtime?model=" + modelName_;
+    apiKey_ = config.apiKey;
+    language_ = config.language;
+    commitIntervalMs_ = std::clamp(config.commitIntervalMs, 1000, 30000);
+
+    FCITX_DEBUG() << "[voice-input:realtime] Init session=" << sessionId
+                  << " endpoint=" << endpoint_;
+}
+
+RealtimeAsrSession::~RealtimeAsrSession() {
+    Cancel();
+    JoinWithTimeout(5s);
+}
+
+void RealtimeAsrSession::StartWorker() {
+    if (!state_->finished && !workerThread_) {
+        auto self = std::static_pointer_cast<RealtimeAsrSession>(shared_from_this());
+        workerThread_ = std::make_unique<std::thread>([self]() { self->WorkerLoop(); });
+    }
+}
+
+void RealtimeAsrSession::FeedAudio(const float* pcm, size_t frames) {
+    if (state_->cancelled || state_->finished) return;
+    if (!audioChunks_) return;
+    std::vector<int16_t> chunk(frames);
+    for (size_t i = 0; i < frames; ++i) {
+        float s = std::clamp(pcm[i], -1.0f, 1.0f);
+        chunk[i] = static_cast<int16_t>(s * 32767.0f);
+    }
+    audioChunks_->Push(std::move(chunk));
+}
+
+void RealtimeAsrSession::End() {
+    state_->finished = true;
+    if (audioChunks_) audioChunks_->Push(std::vector<int16_t>());
+}
+
+void RealtimeAsrSession::Cancel() {
+    state_->cancelled = true;
+    if (audioChunks_) audioChunks_->Push(std::vector<int16_t>());
+}
+
+void RealtimeAsrSession::JoinWithTimeout(std::chrono::milliseconds timeout) {
+    if (workerThread_ && workerThread_->joinable()) {
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < timeout) {
+            std::this_thread::sleep_for(10ms);
+            if (!workerThread_->joinable()) { workerThread_->join(); return; }
+        }
+        FCITX_WARN() << "[voice-input:realtime] Join timeout session="
+                     << state_->sessionId;
+        workerThread_->detach();
+    }
+    workerThread_.reset();
+}
+
+void RealtimeAsrSession::WorkerLoop() {
+    uint64_t sid = state_->sessionId;
+    auto audioChunks = audioChunks_;  // keep queue alive
+    auto cb = resultCb_;
+    auto ecb = errorCb_;
+
+    auto buildAppendEvent = [this](const std::vector<int16_t>& pcm24k) -> std::string {
+        Json::Value ev;
+        ev["type"] = "input_audio_buffer.append";
+        std::vector<uint8_t> bytes(pcm24k.size() * 2);
+        std::memcpy(bytes.data(), pcm24k.data(), bytes.size());
+        ev["audio"] = Base64Encode(bytes.data(), bytes.size());
+        return JsonToString(ev);
+    };
+    auto buildCommitEvent = []() -> std::string {
+        Json::Value ev;
+        ev["type"] = "input_audio_buffer.commit";
+        return JsonToString(ev);
+    };
+    auto buildSessionUpdate = [this]() -> std::string {
+        Json::Value ev;
+        ev["type"] = "session.update";
+        if (!language_.empty()) {
+            ev["session"]["transcription"]["language"] = language_;
+        }
+        if (!modelName_.empty()) {
+            ev["session"]["transcription"]["model"] = modelName_;
+        }
+        return JsonToString(ev);
+    };
+
+    bool gotFinal = false;
+    std::string currentTranscript;
+    std::string lastCommittedTranscript;
+
+    // 连接循环：处理首次连接 + 断线/30min 重连（保持同一 sessionId）
+    for (int attempt = 0; attempt < kMaxReconnectAttempts && !gotFinal; ++attempt) {
+        if (state_->cancelled) break;
+
+        CURL* curl = curl_easy_init();
+        if (!curl) {
+            if (ecb) ecb("Failed to init curl");
+            if (cb) cb("", true, sid);
+            return;
+        }
+
+        struct curl_slist* headers = nullptr;
+        std::string authHeader = "Authorization: Bearer " + apiKey_;
+        headers = curl_slist_append(headers, authHeader.c_str());
+        // GA 接口无需 OpenAI-Beta 头
+
+        curl_easy_setopt(curl, CURLOPT_URL, endpoint_.c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
+        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+        curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+
+        CURLcode connectResult = curl_easy_perform(curl);
+        curl_slist_free_all(headers);
+
+        if (state_->cancelled) {
+            curl_easy_cleanup(curl);
+            break;
+        }
+        if (connectResult != CURLE_OK) {
+            FCITX_ERROR() << "[voice-input:realtime] WS connect failed: "
+                          << curl_easy_strerror(connectResult) << " attempt=" << attempt;
+            curl_easy_cleanup(curl);
+            if (attempt == kMaxReconnectAttempts - 1) {
+                if (ecb) ecb("Realtime connect failed: " + std::string(curl_easy_strerror(connectResult)));
+                if (cb) cb("", true, sid);
+                return;
+            }
+            std::this_thread::sleep_for(1s);
+            continue;
+        }
+
+        FCITX_INFO() << "[voice-input:realtime] WS connected session=" << sid;
+
+        // 会话开始：发送 session.update（语言/模型提示）
+        SendWebSocketText(curl, buildSessionUpdate(), state_->cancelled);
+
+        auto sessionStart = std::chrono::steady_clock::now();
+        auto lastCommitTime = sessionStart;
+        std::vector<int16_t> pending24k;
+
+        // 处理服务端事件
+        auto handleServer = [&](std::chrono::milliseconds timeout) {
+            auto deadline = std::chrono::steady_clock::now() + timeout;
+            while (!state_->cancelled && !gotFinal &&
+                   std::chrono::steady_clock::now() < deadline) {
+                std::string text;
+                RecvStatus r = ReceiveTextFrame(curl, text);
+                if (r == RecvStatus::Again) { std::this_thread::sleep_for(10ms); continue; }
+                if (r == RecvStatus::Closed) { gotFinal = true; return false; }
+                if (r == RecvStatus::Error) { if (ecb) ecb("WS recv error"); return false; }
+
+                Json::Value json;
+                Json::Reader reader;
+                if (!reader.parse(text, json)) continue;
+
+                std::string type = json.get("type", "").asString();
+                if (type == "conversation.item.input_audio_transcription.delta") {
+                    currentTranscript += json.get("delta", "").asString();
+                    if (cb && !currentTranscript.empty()) cb(currentTranscript, false, sid);
+                } else if (type == "conversation.item.input_audio_transcription.completed") {
+                    std::string transcript = json.get("transcript", "").asString();
+                    currentTranscript.clear();
+                    if (cb && !transcript.empty()) cb(transcript, true, sid);
+                } else if (type == "conversation.item.input_audio_transcription.failed") {
+                    if (ecb) ecb("Transcription failed");
+                    currentTranscript.clear();
+                }
+                // 其他事件（response.*/error 等）忽略
+            }
+            return true;
+        };
+
+        bool reconnectNeeded = false;
+        while (!state_->cancelled && !gotFinal && !reconnectNeeded) {
+            std::vector<int16_t> chunk;
+            bool hasChunk = audioChunks->TryPop(chunk);
+
+            if (hasChunk && chunk.empty() && state_->finished) {
+                // 语音结束 → 提交最终段
+                SendWebSocketText(curl, buildCommitEvent(), state_->cancelled);
+                auto deadline = std::chrono::steady_clock::now() + 30s;
+                while (!state_->cancelled && !gotFinal &&
+                       std::chrono::steady_clock::now() < deadline) {
+                    if (!handleServer(50ms)) { gotFinal = true; break; }
+                }
+                break;
+            }
+            if (hasChunk && !chunk.empty()) {
+                // 16k int16 → 24k float → 24k int16
+                std::vector<float> f16(chunk.size());
+                for (size_t i = 0; i < chunk.size(); ++i)
+                    f16[i] = static_cast<float>(chunk[i]) / 32768.0f;
+                std::vector<float> f24;
+                Upsample16kTo24k(f16, f24);
+                std::vector<int16_t> i24(f24.size());
+                for (size_t i = 0; i < f24.size(); ++i)
+                    i24[i] = static_cast<int16_t>(std::clamp(f24[i], -1.0f, 1.0f) * 32767.0f);
+                pending24k.insert(pending24k.end(), i24.begin(), i24.end());
+            }
+
+            // 周期 commit 兜底（长句无停顿也能出增量）
+            auto now = std::chrono::steady_clock::now();
+            auto elapsedSinceCommit = std::chrono::duration_cast<std::chrono::milliseconds>(
+                now - lastCommitTime).count();
+            if (!pending24k.empty() &&
+                elapsedSinceCommit >= commitIntervalMs_) {
+                SendWebSocketText(curl, buildCommitEvent(), state_->cancelled);
+                lastCommitTime = now;
+            }
+
+            // 推送足够粒度的音频
+            if (pending24k.size() >= kAppendChunkSamples && !state_->cancelled) {
+                size_t sendSize = (pending24k.size() / kAppendChunkSamples) * kAppendChunkSamples;
+                std::vector<int16_t> toSend(pending24k.begin(), pending24k.begin() + sendSize);
+                if (!SendWebSocketText(curl, buildAppendEvent(toSend), state_->cancelled)) {
+                    reconnectNeeded = true;
+                    break;
+                }
+                pending24k.erase(pending24k.begin(), pending24k.begin() + sendSize);
+                lastCommitTime = std::chrono::steady_clock::now();
+            }
+
+            // 30min 会话上限：强制 commit + 重连
+            auto sessionAge = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - sessionStart).count();
+            if (sessionAge >= kSessionMaxDuration.count()) {
+                FCITX_WARN() << "[voice-input:realtime] 30min session limit, reconnect";
+                SendWebSocketText(curl, buildCommitEvent(), state_->cancelled);
+                reconnectNeeded = true;
+                break;
+            }
+
+            if (!handleServer(20ms)) { gotFinal = true; break; }
+            std::this_thread::sleep_for(5ms);
+        }
+
+        CloseWebSocket(curl);
+        curl_easy_cleanup(curl);
+
+        if (state_->cancelled || gotFinal) break;
+        if (reconnectNeeded) {
+            FCITX_WARN() << "[voice-input:realtime] Reconnecting session=" << sid;
+            std::this_thread::sleep_for(1s);
+            continue;
+        }
+    }
+
+    if (state_->cancelled) {
+        FCITX_DEBUG() << "[voice-input:realtime] Cancelled session=" << sid;
+        return;
+    }
+    if (!gotFinal || currentTranscript.empty()) {
+        // 无最终结果：以空 final 触发 pipeline 错误/清理分支
+        if (cb) cb("", true, sid);
+    }
+}
+
+// ── RealtimeAsrEngine ─────────────────────────────────────────
+
+bool RealtimeAsrEngine::Init(const Config& config) {
+    config_ = config;
+    return true;
+}
+
+std::shared_ptr<AsrSession> RealtimeAsrEngine::StartSession() {
+    uint64_t sid;
+    {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        sid = nextSessionId_++;
+    }
+
+    auto session = std::make_shared<RealtimeAsrSession>(config_, errorCb_, sid);
+    session->SetResultCallback(resultCb_);
+    if (!session->GetState()->finished)
+        session->StartWorker();
+
+    {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        sessions_[sid] = session;
+    }
+    return session;
+}
+
+} // namespace fcitx

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -392,8 +392,8 @@ void RealtimeAsrSession::WorkerLoop() {
         FCITX_DEBUG() << "[voice-input:realtime] Cancelled session=" << sid;
         return;
     }
-    if (!gotFinal || currentTranscript.empty()) {
-        // 无最终结果：以空 final 触发 pipeline 错误/清理分支
+    if (!gotFinal) {
+        // 未收到最终转录（连接断开/失败）：以空 final 触发 pipeline 错误/清理分支
         if (cb) cb("", true, sid);
     }
 }

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -23,22 +23,22 @@ constexpr int kAppendChunkSamples = 2400; // ~100ms @24k 音频推送粒度（�
 
 enum class RecvStatus { Ok, Again, Closed, Error };
 
-// 16k float → 24k float 线性插值（比例 3/2）。每 2 个源样本插出 3 个目标样本。
+// 16k → 24k 线性插值（比例 3/2）。输出样本数 = floor(1.5 * N)。
+// 对每个输出下标 j，其对应的源位置 pos = j * 2/3，在相邻源样本间线性插值。
 void Upsample16kTo24k(const std::vector<float>& in, std::vector<float>& out) {
     out.clear();
-    out.reserve(in.size() * 3 / 2 + 2);
-    if (in.size() < 2) {
-        for (float s : in) out.push_back(s);
-        return;
-    }
-    for (size_t i = 0; i + 1 < in.size(); ++i) {
+    if (in.empty()) return;
+    size_t outCount = in.size() * 3 / 2;
+    if (outCount == 0) return;
+    out.reserve(outCount);
+    for (size_t j = 0; j < outCount; ++j) {
+        double pos = j * (2.0 / 3.0);
+        size_t i = static_cast<size_t>(pos);
+        double frac = pos - static_cast<double>(i);
         float a = in[i];
-        float b = in[i + 1];
-        out.push_back(a);                    // t=0/3
-        out.push_back(a + (b - a) * 2.0f / 3.0f); // t=2/3
-        out.push_back(a + (b - a) * 1.0f / 3.0f); // t=1/3（插值顺序交错）
+        float b = (i + 1 < in.size()) ? in[i + 1] : a;  // 末端 clamp
+        out.push_back(a + static_cast<float>((b - a) * frac));
     }
-    out.push_back(in.back());
 }
 
 std::string JsonToString(const Json::Value& json) {
@@ -127,6 +127,13 @@ RealtimeAsrSession::RealtimeAsrSession(const AsrEngine::Config& config,
     language_ = config.language;
     commitIntervalMs_ = std::clamp(config.commitIntervalMs, 1000, 30000);
 
+    if (apiKey_.empty()) {
+        state_->finished = true;
+        if (errorCb_) errorCb_("OpenAI API key not configured");
+        if (resultCb_) resultCb_("", true, state_->sessionId);
+        return;
+    }
+
     FCITX_DEBUG() << "[voice-input:realtime] Init session=" << sessionId
                   << " endpoint=" << endpoint_;
 }
@@ -211,7 +218,7 @@ void RealtimeAsrSession::WorkerLoop() {
 
     bool gotFinal = false;
     std::string currentTranscript;
-    std::string lastCommittedTranscript;
+    std::vector<int16_t> pending24k;  // 提升到连接循环外，重连时保留未发送缓冲
 
     // 连接循环：处理首次连接 + 断线/30min 重连（保持同一 sessionId）
     for (int attempt = 0; attempt < kMaxReconnectAttempts && !gotFinal; ++attempt) {
@@ -262,7 +269,6 @@ void RealtimeAsrSession::WorkerLoop() {
 
         auto sessionStart = std::chrono::steady_clock::now();
         auto lastCommitTime = sessionStart;
-        std::vector<int16_t> pending24k;
 
         // 处理服务端事件
         auto handleServer = [&](std::chrono::milliseconds timeout) {
@@ -285,8 +291,19 @@ void RealtimeAsrSession::WorkerLoop() {
                     if (cb && !currentTranscript.empty()) cb(currentTranscript, false, sid);
                 } else if (type == "conversation.item.input_audio_transcription.completed") {
                     std::string transcript = json.get("transcript", "").asString();
-                    currentTranscript.clear();
-                    if (cb && !transcript.empty()) cb(transcript, true, sid);
+                    bool end = state_->finished;
+                    if (end) {
+                        // VAD End 已触发 → 最终结果，上报 final 并结束会话
+                        if (cb && !transcript.empty()) cb(transcript, true, sid);
+                        currentTranscript.clear();
+                        gotFinal = true;
+                        return false;
+                    } else {
+                        // 周期 commit 产生的中间转录 → 作为增量 partial 刷新 preedit
+                        // （pipeline 契约：每个会话仅一个 final，此处不得上报 final）
+                        if (cb && !transcript.empty()) cb(transcript, false, sid);
+                        currentTranscript.clear();
+                    }
                 } else if (type == "conversation.item.input_audio_transcription.failed") {
                     if (ecb) ecb("Transcription failed");
                     currentTranscript.clear();
@@ -392,6 +409,11 @@ std::shared_ptr<AsrSession> RealtimeAsrEngine::StartSession() {
     uint64_t sid;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
+        // 清理过期 weak_ptr，避免长期运行 map 无限增长
+        for (auto it = sessions_.begin(); it != sessions_.end(); ) {
+            if (it->second.expired()) it = sessions_.erase(it);
+            else ++it;
+        }
         sid = nextSessionId_++;
     }
 

--- a/src/addon/asr/realtime_asr.h
+++ b/src/addon/asr/realtime_asr.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "asr_engine.h"
+#include "asr_session.h"
+#include "utils/thread_safe_queue.h"
+
+namespace fcitx {
+
+/// OpenAI Realtime 流式实时转录会话。
+///
+/// 与 VolcengineAsrSession 结构对齐：StartWorker 即建 WS 持久连接，
+/// FeedAudio 转 int16 入队，worker 线程内做 16k→24k 重采样、base64 推送、
+/// 解析 delta/completed 事件。支持周期性 commit 兜底与断线重连（保持 sessionId）。
+class RealtimeAsrSession : public AsrSession {
+public:
+    RealtimeAsrSession(const AsrEngine::Config& config,
+                       AsrSession::ErrorCallback errorCb,
+                       uint64_t sessionId);
+    ~RealtimeAsrSession() override;
+
+    void FeedAudio(const float* pcm, size_t frames) override;
+    void End() override;
+    void Cancel() override;
+    void JoinWithTimeout(std::chrono::milliseconds timeout) override;
+    void StartWorker() override;
+
+private:
+    void WorkerLoop();
+
+    // Config snapshot (copied at construction, safe for worker)
+    std::string endpoint_;
+    std::string apiKey_;
+    std::string modelName_;
+    std::string language_;
+    int commitIntervalMs_ = 5000;
+    static constexpr int kMaxReconnectAttempts = 3;
+    static constexpr std::chrono::seconds kSessionMaxDuration = std::chrono::seconds(30 * 60);
+
+    std::shared_ptr<ThreadSafeQueue<std::vector<int16_t>>> audioChunks_;
+    std::unique_ptr<std::thread> workerThread_;
+};
+
+class RealtimeAsrEngine : public AsrEngine {
+public:
+    bool Init(const Config& config) override;
+    std::shared_ptr<AsrSession> StartSession() override;
+    const char* Name() const override { return "realtime"; }
+
+private:
+    Config config_;
+};
+
+} // namespace fcitx

--- a/src/addon/asr/utils/base64.cpp
+++ b/src/addon/asr/utils/base64.cpp
@@ -1,0 +1,25 @@
+#include "base64.h"
+
+namespace fcitx {
+
+namespace {
+const char b64table[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+}
+
+std::string Base64Encode(const uint8_t* data, size_t len) {
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    for (size_t i = 0; i < len; i += 3) {
+        uint32_t v = (static_cast<uint32_t>(data[i]) << 16)
+                   | (i + 1 < len ? static_cast<uint32_t>(data[i + 1]) << 8 : 0)
+                   | (i + 2 < len ? static_cast<uint32_t>(data[i + 2]) : 0);
+        out.push_back(b64table[(v >> 18) & 0x3F]);
+        out.push_back(b64table[(v >> 12) & 0x3F]);
+        out.push_back(i + 1 < len ? b64table[(v >> 6) & 0x3F] : '=');
+        out.push_back(i + 2 < len ? b64table[v & 0x3F] : '=');
+    }
+    return out;
+}
+
+} // namespace fcitx

--- a/src/addon/asr/utils/base64.h
+++ b/src/addon/asr/utils/base64.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace fcitx {
+
+/// Base64 编码，供 OpenAI Realtime（音频 base64）等流式路径复用。
+/// 提取自 openai_asr.cpp 的匿名 namespace 实现，提升为公共函数。
+std::string Base64Encode(const uint8_t* data, size_t len);
+
+} // namespace fcitx

--- a/src/addon/config/voiceinput-config.h
+++ b/src/addon/config/voiceinput-config.h
@@ -53,6 +53,8 @@ struct ApiModeAnnotation : public EnumAnnotation {
         config.setValueByPath("EnumI18n/0", _("Standard Whisper API"));
         config.setValueByPath("Enum/1", "chat");
         config.setValueByPath("EnumI18n/1", _("Chat Completions"));
+        config.setValueByPath("Enum/2", "realtime");
+        config.setValueByPath("EnumI18n/2", _("GPT Realtime (Streaming)"));
     }
 };
 
@@ -91,6 +93,10 @@ FCITX_CONFIGURATION(OpenAIAsrConfig,
            DefaultMarshaller<std::string>, ApiModeAnnotation>
         apiMode{
             this, "ApiMode", _("API 模式"), "whisper"};
+
+    Option<int, IntConstrain> commitIntervalMs{
+        this, "CommitIntervalMs", _("实时提交间隔 (毫秒)"), 5000,
+        IntConstrain(1000, 30000)};
 );
 
 FCITX_CONFIGURATION(VolcengineAsrConfig,

--- a/src/addon/engine.cpp
+++ b/src/addon/engine.cpp
@@ -17,6 +17,7 @@
 #include "engine.h"
 
 #include "asr/openai_asr.h"
+#include "asr/realtime_asr.h"
 #include "asr/volcengine_asr.h"
 #include "llm/llm_client.h"
 
@@ -341,6 +342,7 @@ std::unique_ptr<AsrEngine> VoiceInputEngine::CreateAsrEngine() {
         asrConfig.apiKey = *openaiConfig_.apiKey;
         asrConfig.modelName = *openaiConfig_.model;
         asrConfig.apiMode = *openaiConfig_.apiMode;
+        asrConfig.commitIntervalMs = *openaiConfig_.commitIntervalMs;
         auto language = *openaiConfig_.language;
         if (language == "auto") {
             language.clear();
@@ -348,8 +350,13 @@ std::unique_ptr<AsrEngine> VoiceInputEngine::CreateAsrEngine() {
         asrConfig.language = language;
         FCITX_INFO() << "[voice-input] OpenAI config: endpoint="
                      << asrConfig.apiEndpoint
-                     << " model=" << asrConfig.modelName;
-        asr = std::make_unique<OpenaiAsrEngine>();
+                     << " model=" << asrConfig.modelName
+                     << " apiMode=" << asrConfig.apiMode;
+        if (asrConfig.apiMode == "realtime") {
+            asr = std::make_unique<RealtimeAsrEngine>();
+        } else {
+            asr = std::make_unique<OpenaiAsrEngine>();
+        }
     }
 
     if (asr->Init(asrConfig)) {


### PR DESCRIPTION
# GPT-Realtime 流式实时转录支持

Closes #10

## 概述
在 OpenAI 后端新增 Realtime 流式实时转录：边说边出增量 preedit，语音段结束后提交最终结果上屏。

## 进度
- [x] 调研（已并入 main）
- [x] 技术方案 + ADR + DAG 任务拆解
- [x] 编码实现（T1-T8）
- [ ] 审查
- [ ] 合并

## 关键决策
- 新增独立 `RealtimeAsrEngine`，复用现有 AsrEngine/AsrSession 接口
- 16k→24k 线性重采样
- libcurl>=7.86 内置 WebSocket，零新依赖
- 推荐模型 `gpt-live-transcribe`（`gpt-realtime-whisper` 可选）
- 实时增量经现有 `isPartial`→preedit 链路，pipeline 零改动
- 周期性 commit 兜底（commitIntervalMs）+ 断线重连 + 30min 会话

## 实现
- `src/addon/asr/realtime_asr.h/.cpp`：RealtimeAsrEngine + RealtimeAsrSession（WS 客户端、重采样、delta/completed、commit/重连）
- `src/addon/asr/utils/base64.h/.cpp`：Base64Encode 提升为公共工具
- `src/addon/config/voiceinput-config.h`：ApiMode 增 `realtime`，新增 `CommitIntervalMs`
- `src/addon/engine.cpp`：工厂按 apiMode 分流
- `CMakeLists.txt`：接入新源文件
- README：Realtime 模式文档

## 参考
- 调研: `docs/dev/research/gpt-realtime-whisper.md`
- 方案: `docs/dev/specs/gpt-realtime-asr.md`