### PR TITLE
fix(concurrency): 修复会话线程 UAF 与数据竞争（issue #14 审查问题 1/2/3/8）

### DIFF
--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -62,6 +62,13 @@ size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     return size * nmemb;
 }
 
+// 进度回调：会话被取消时中断在途 HTTP 传输（返回非 0 中止请求）
+int CancelProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
+                           curl_off_t) {
+    auto* cancelled = static_cast<std::atomic<bool>*>(clientp);
+    return cancelled->load() ? 1 : 0;
+}
+
 // Base64 编码已提取到 utils/base64.h，此处复用公共实现。
 
 std::string BuildMultipartBody(const std::vector<uint8_t>& wavData,
@@ -139,9 +146,12 @@ void OpenaiAsrSession::End() {
         if (pcmBuffer_.empty()) return;
         buffer.swap(pcmBuffer_);
     }
+    // 用 shared_from_this 保活会话：worker 线程可能因慢网络在 JoinWithTimeout
+    // 超时后被 detach，此时会话对象仍必须存活，否则成员访问构成 use-after-free。
+    auto self = std::static_pointer_cast<OpenaiAsrSession>(shared_from_this());
     workerThread_ = std::make_unique<std::thread>(
-        [this, buf = std::move(buffer)]() mutable {
-            TranscribeWorker(std::move(buf));
+        [self, buf = std::move(buffer)]() mutable {
+            self->TranscribeWorker(std::move(buf));
         });
 }
 
@@ -262,6 +272,10 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    // Cancel() 后立即中断在途传输，避免 JoinWithTimeout 超时 detach
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &state->cancelled);
 
     CURLcode res = curl_easy_perform(curl);
 

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -20,6 +20,13 @@ size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     return total;
 }
 
+// 进度回调：Cancel() 后中断在途 HTTP 传输（返回非 0 中止请求）
+int CancelProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
+                           curl_off_t) {
+    auto* cancelled = static_cast<std::atomic<bool>*>(clientp);
+    return cancelled->load() ? 1 : 0;
+}
+
 // Extract "text" field from a JSON response.
 // Returns empty string on parse failure or missing field.
 std::string ExtractJsonText(const std::string& content) {
@@ -169,6 +176,10 @@ std::string LLMClient::Process(const std::string& text) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    // Cancel() 后中断在途传输
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled_);
 
     CURLcode res = curl_easy_perform(curl);
 
@@ -316,6 +327,10 @@ void LLMClient::ProcessStream(const std::string& text,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    // Cancel() 后中断在途传输
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled_);
 
     CURLcode res = curl_easy_perform(curl);
 

--- a/src/addon/llm/llm_client.h
+++ b/src/addon/llm/llm_client.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <string>
+#include <atomic>
 #include <functional>
+#include <string>
 #include <vector>
 
 namespace fcitx {
@@ -31,8 +32,12 @@ public:
                        std::function<void(const std::string&)> onToken,
                        std::function<void(const std::string&)> onComplete);
 
+    /// 取消在途请求：中断当前阻塞的 HTTP 传输，后续调用立即返回。
+    void Cancel() { cancelled_.store(true); }
+
 private:
     Config config_;
+    std::atomic<bool> cancelled_{false};
 };
 
 } // namespace fcitx

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -70,110 +70,132 @@ void Pipeline::SetLLMClient(std::unique_ptr<LLMClient> client) {
 }
 
 void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
-    asrEngine_ = std::move(engine);
-    if (asrEngine_) {
-        asrEngine_->SetResultCallback(
-            [this](const std::string& text, bool isFinal, uint64_t sid) {
-                // Look up generation captured at session start
+    std::shared_ptr<AsrEngine> enginePtr = std::move(engine);
+    if (!enginePtr) {
+        std::lock_guard<std::mutex> lock(engineMutex_);
+        asrEngine_ = nullptr;
+        return;
+    }
+    enginePtr->SetResultCallback(
+        [this, guard = resultGuard_](const std::string& text, bool isFinal,
+                                     uint64_t sid) {
+            // 会话 worker 线程可能晚于管线析构退出（reaper 超时 detach），
+            // 回调前检查守卫，避免访问已析构的 Pipeline。
+            if (!guard->load()) return;
+
+            // Look up generation captured at session start
+            uint64_t gen = 0;
+            {
+                std::lock_guard<std::mutex> lock(sessionMapMutex_);
                 auto it = sessionGenerationMap_.find(sid);
                 if (it == sessionGenerationMap_.end()) return;
-                uint64_t gen = it->second;
-
+                gen = it->second;
                 if (isFinal) {
-                    if (text.empty()) {
-                        AsrResult errorResult;
-                        errorResult.generation = gen;
-                        errorResult.sessionId = sid;
-                        errorResult.isError = true;
-                        resultQueue_.Push(std::move(errorResult));
-                        if (resultCb_) resultCb_(text);
-                        sessionGenerationMap_.erase(sid);
-                        return;
-                    }
-
-                    uint64_t uid = ++utteranceCounter_;
-
-                    AsrResult stale;
-                    while (resultQueue_.TryPop(stale)) {
-                        if (stale.isLLMRefined) {
-                            FCITX_DEBUG() << "[voice-input] Drained stale LLM result: "
-                                         << "uid=" << stale.utteranceId;
-                        }
-                    }
-
-                    AsrResult rawResult;
-                    rawResult.text = text;
-                    rawResult.generation = gen;
-                    rawResult.sessionId = sid;
-                    rawResult.utteranceId = uid;
-                    rawResult.isLLMRefined = false;
-                    FCITX_DEBUG() << "[voice-input] ASR raw: uid=" << uid
-                                 << " text=\"" << text << "\"";
-                    resultQueue_.Push(std::move(rawResult));
-
-                    if (resultCb_) {
-                        resultCb_(text);
-                    }
-
-                    if (llmClient_) {
-                        FCITX_DEBUG() << "[voice-input] LLM refine started"
-                                     << " uid=" << uid << " gen=" << gen
-                                     << " stream=" << llmStream_;
-                        if (llmStream_) {
-                            llmClient_->ProcessStream(text,
-                                [this, uid, gen, sid](const std::string& partial) {
-                                    AsrResult partialResult;
-                                    partialResult.text = partial;
-                                    partialResult.generation = gen;
-                                    partialResult.sessionId = sid;
-                                    partialResult.utteranceId = uid;
-                                    partialResult.isLLMRefined = true;
-                                    partialResult.isPartial = true;
-                                    resultQueue_.Push(std::move(partialResult));
-                                    if (resultCb_) resultCb_(partial);
-                                },
-                                [this, uid, gen, sid](const std::string& fullText) {
-                                    AsrResult finalResult;
-                                    finalResult.text = fullText;
-                                    finalResult.generation = gen;
-                                    finalResult.sessionId = sid;
-                                    finalResult.utteranceId = uid;
-                                    finalResult.isLLMRefined = true;
-                                    finalResult.isPartial = false;
-                                    resultQueue_.Push(std::move(finalResult));
-                                    if (resultCb_) resultCb_(fullText);
-                                });
-                        } else {
-                            std::string processed = llmClient_->Process(text);
-                            if (!processed.empty()) {
-                                AsrResult refinedResult;
-                                refinedResult.text = processed;
-                                refinedResult.generation = gen;
-                                refinedResult.sessionId = sid;
-                                refinedResult.utteranceId = uid;
-                                refinedResult.isLLMRefined = true;
-                                resultQueue_.Push(std::move(refinedResult));
-                                if (resultCb_) resultCb_(processed);
-                            }
-                        }
-                    }
                     sessionGenerationMap_.erase(sid);
-                } else if (!text.empty()) {
-                    AsrResult partial;
-                    partial.text = text;
-                    partial.generation = gen;
-                    partial.sessionId = sid;
-                    partial.isLLMRefined = false;
-                    partial.isPartial = true;
-                    resultQueue_.Push(std::move(partial));
-                    if (resultCb_) resultCb_(text);
                 }
-            });
-        asrEngine_->SetErrorCallback(
-            [this](const std::string& error) {
-                FCITX_ERROR() << "[voice-input] ASR error: " << error;
-            });
-    }
+            }
+
+            if (isFinal) {
+                if (text.empty()) {
+                    AsrResult errorResult;
+                    errorResult.generation = gen;
+                    errorResult.sessionId = sid;
+                    errorResult.isError = true;
+                    resultQueue_.Push(std::move(errorResult));
+                    if (resultCb_) resultCb_(text);
+                    return;
+                }
+
+                uint64_t uid = ++utteranceCounter_;
+
+                AsrResult stale;
+                while (resultQueue_.TryPop(stale)) {
+                    if (stale.isLLMRefined) {
+                        FCITX_DEBUG() << "[voice-input] Drained stale LLM result: "
+                                     << "uid=" << stale.utteranceId;
+                    }
+                }
+
+                AsrResult rawResult;
+                rawResult.text = text;
+                rawResult.generation = gen;
+                rawResult.sessionId = sid;
+                rawResult.utteranceId = uid;
+                rawResult.isLLMRefined = false;
+                FCITX_DEBUG() << "[voice-input] ASR raw: uid=" << uid
+                             << " text=\"" << text << "\"";
+                resultQueue_.Push(std::move(rawResult));
+
+                if (resultCb_) {
+                    resultCb_(text);
+                }
+
+                if (llmClient_) {
+                    FCITX_DEBUG() << "[voice-input] LLM refine started"
+                                 << " uid=" << uid << " gen=" << gen
+                                 << " stream=" << llmStream_;
+                    if (llmStream_) {
+                        llmClient_->ProcessStream(text,
+                            [this, guard, uid, gen,
+                             sid](const std::string& partial) {
+                                if (!guard->load()) return;
+                                AsrResult partialResult;
+                                partialResult.text = partial;
+                                partialResult.generation = gen;
+                                partialResult.sessionId = sid;
+                                partialResult.utteranceId = uid;
+                                partialResult.isLLMRefined = true;
+                                partialResult.isPartial = true;
+                                resultQueue_.Push(std::move(partialResult));
+                                if (resultCb_) resultCb_(partial);
+                            },
+                            [this, guard, uid, gen,
+                             sid](const std::string& fullText) {
+                                if (!guard->load()) return;
+                                AsrResult finalResult;
+                                finalResult.text = fullText;
+                                finalResult.generation = gen;
+                                finalResult.sessionId = sid;
+                                finalResult.utteranceId = uid;
+                                finalResult.isLLMRefined = true;
+                                finalResult.isPartial = false;
+                                resultQueue_.Push(std::move(finalResult));
+                                if (resultCb_) resultCb_(fullText);
+                            });
+                    } else {
+                        std::string processed = llmClient_->Process(text);
+                        if (!processed.empty()) {
+                            AsrResult refinedResult;
+                            refinedResult.text = processed;
+                            refinedResult.generation = gen;
+                            refinedResult.sessionId = sid;
+                            refinedResult.utteranceId = uid;
+                            refinedResult.isLLMRefined = true;
+                            resultQueue_.Push(std::move(refinedResult));
+                            if (resultCb_) resultCb_(processed);
+                        }
+                    }
+                }
+            } else if (!text.empty()) {
+                AsrResult partial;
+                partial.text = text;
+                partial.generation = gen;
+                partial.sessionId = sid;
+                partial.isLLMRefined = false;
+                partial.isPartial = true;
+                resultQueue_.Push(std::move(partial));
+                if (resultCb_) resultCb_(text);
+            }
+        });
+    enginePtr->SetErrorCallback(
+        [this, guard = resultGuard_](const std::string& error) {
+            if (!guard->load()) return;
+            FCITX_ERROR() << "[voice-input] ASR error: " << error;
+        });
+
+    // 先绑定回调再发布指针，ASR 线程随后在锁内取用，避免使用到未绑定的引擎
+    std::lock_guard<std::mutex> lock(engineMutex_);
+    asrEngine_ = std::move(enginePtr);
 }
 
 void Pipeline::SetResultCallback(ResultCallback cb) {
@@ -230,8 +252,18 @@ void Pipeline::Stop() {
     }
 
     // Cancel all engine sessions (old ones will be cleaned by reaper)
-    if (asrEngine_) {
-        asrEngine_->CancelAllSessions();
+    std::shared_ptr<AsrEngine> engine;
+    {
+        std::lock_guard<std::mutex> lock(engineMutex_);
+        engine = asrEngine_;
+    }
+    if (engine) {
+        engine->CancelAllSessions();
+    }
+
+    // 停止 LLM 后处理（中断在途请求）
+    if (llmClient_) {
+        llmClient_->Cancel();
     }
 
     if (capture_) {
@@ -241,7 +273,10 @@ void Pipeline::Stop() {
     // Drain remaining results
     AsrResult r;
     while (resultQueue_.TryPop(r)) {}
-    sessionGenerationMap_.clear();
+    {
+        std::lock_guard<std::mutex> lock(sessionMapMutex_);
+        sessionGenerationMap_.clear();
+    }
 
     FCITX_INFO() << "[voice-input] Pipeline stopped";
 }
@@ -267,8 +302,17 @@ void Pipeline::Abort() {
         activeSessionId_ = 0;
     }
 
-    if (asrEngine_) {
-        asrEngine_->CancelAllSessions();
+    std::shared_ptr<AsrEngine> engine;
+    {
+        std::lock_guard<std::mutex> lock(engineMutex_);
+        engine = asrEngine_;
+    }
+    if (engine) {
+        engine->CancelAllSessions();
+    }
+
+    if (llmClient_) {
+        llmClient_->Cancel();
     }
 
     // Clear queues
@@ -278,6 +322,9 @@ void Pipeline::Abort() {
     while (speechEventQueue_.TryPop(se)) {}
     AsrResult r;
     while (resultQueue_.TryPop(r)) {}
+
+    // 终态：回调守卫失效，引擎 worker 线程的异步回调全部丢弃
+    resultGuard_->store(false);
 }
 
 bool Pipeline::StartCapture() {
@@ -312,26 +359,40 @@ void Pipeline::AsrDispatcherLoop() {
         }
 
         switch (ev.type) {
-        case SpeechEventType::Begin:
-            if (!asrEngine_) break;
+        case SpeechEventType::Begin: {
+            // 取引擎局部引用：SetAsrEngine 可能随时替换指针，持锁拷贝保证
+            // StartSession 期间引擎对象存活
+            std::shared_ptr<AsrEngine> engine;
+            {
+                std::lock_guard<std::mutex> lock(engineMutex_);
+                engine = asrEngine_;
+            }
+            if (!engine) break;
             // Cancel current session if still active
             if (activeSession_) {
-                sessionGenerationMap_.erase(activeSessionId_);
+                {
+                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
+                    sessionGenerationMap_.erase(activeSessionId_);
+                }
                 activeSession_->Cancel();
                 reaper_->Add(std::move(activeSession_));
                 activeSessionId_ = 0;
             }
             // Start new session
-            activeSession_ = asrEngine_->StartSession();
+            activeSession_ = engine->StartSession();
             if (activeSession_) {
                 activeSessionId_ = activeSession_->GetState()->sessionId;
-                sessionGenerationMap_[activeSessionId_] = generation_.load();
+                {
+                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
+                    sessionGenerationMap_[activeSessionId_] = generation_.load();
+                }
                 FCITX_DEBUG() << "[voice-input:asr] Begin -> session="
                              << activeSessionId_
-                             << " gen=" << sessionGenerationMap_[activeSessionId_];
+                             << " gen=" << generation_.load();
             }
             pendingAsrAudio_.clear();
             break;
+        }
 
         case SpeechEventType::Audio:
             if (!activeSession_ || ev.pcm.empty()) break;

--- a/src/addon/pipeline/pipeline.h
+++ b/src/addon/pipeline/pipeline.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -64,10 +65,12 @@ private:
     std::unique_ptr<AudioCapture> capture_;
 
     // ASR session management
-    std::unique_ptr<AsrEngine> asrEngine_;
+    std::shared_ptr<AsrEngine> asrEngine_;
     std::shared_ptr<AsrSession> activeSession_;
     uint64_t activeSessionId_{0};
     std::unordered_map<uint64_t, uint64_t> sessionGenerationMap_;
+    std::mutex sessionMapMutex_;   // 保护 sessionGenerationMap_（worker/ASR/主线程三方）
+    std::mutex engineMutex_;       // 保护 asrEngine_ 指针替换与使用
     std::unique_ptr<SessionReaper> reaper_;
 
     // ASR streaming batching
@@ -80,7 +83,10 @@ private:
     // State
     std::atomic<bool> running_{false};
     std::atomic<uint64_t> generation_{0};
-    uint64_t utteranceCounter_{0};
+    std::atomic<uint64_t> utteranceCounter_{0};
+    // 回调守卫：Abort 后置 false，引擎 worker 线程的异步回调据此丢弃
+    std::shared_ptr<std::atomic<bool>> resultGuard_ =
+        std::make_shared<std::atomic<bool>>(true);
 
     // Config
     VoiceInputConfig config_;

--- a/src/addon/vad/vad.cpp
+++ b/src/addon/vad/vad.cpp
@@ -22,6 +22,10 @@ int64_t NowMs() {
         .count();
 }
 
+size_t PreRollSamples(int preRollMs) {
+    return static_cast<size_t>(kSampleRate) * preRollMs / 1000;
+}
+
 } // namespace
 
 VADWorker::VADWorker() = default;
@@ -31,16 +35,19 @@ VADWorker::~VADWorker() {
 }
 
 void VADWorker::SetConfig(const Config& config) {
-    config_ = config;
+    {
+        std::lock_guard<std::mutex> lock(configMutex_);
+        config_ = config;
+    }
 
     FCITX_INFO() << "[voice-input:vadworker] Config:"
-                 << " speechThresh=" << config_.speechThreshold
-                 << " silenceThresh=" << config_.silenceThreshold
-                 << " startFrames=" << config_.startFrames
-                 << " preRollMs=" << config_.preRollMs
-                 << " endSilenceMs=" << config_.endSilenceMs
-                 << " minSpeechMs=" << config_.minSpeechMs
-                 << " maxSpeechMs=" << config_.maxSpeechMs;
+                 << " speechThresh=" << config.speechThreshold
+                 << " silenceThresh=" << config.silenceThreshold
+                 << " startFrames=" << config.startFrames
+                 << " preRollMs=" << config.preRollMs
+                 << " endSilenceMs=" << config.endSilenceMs
+                 << " minSpeechMs=" << config.minSpeechMs
+                 << " maxSpeechMs=" << config.maxSpeechMs;
 }
 
 void VADWorker::SetFrameQueue(ThreadSafeQueue<AudioFrame>* queue) {
@@ -94,28 +101,36 @@ void VADWorker::WorkerLoop() {
             continue;
         }
 
+        // 快照配置：SetConfig 可能在主线程并发改写 config_
+        Config config;
+        {
+            std::lock_guard<std::mutex> lock(configMutex_);
+            config = config_;
+        }
+
         float prob = silero_->Predict(frame.pcm.data(), frame.pcm.size());
         if (prob < 0.0f) {
             // Inference failed
             continue;
         }
 
-        ProcessFrame(frame, prob);
+        ProcessFrame(frame, prob, config);
     }
 }
 
-void VADWorker::ProcessFrame(const AudioFrame& frame, float probability) {
-    bool speechStart = probability >= config_.speechThreshold;
-    bool speechKeep = probability >= config_.silenceThreshold;
+void VADWorker::ProcessFrame(const AudioFrame& frame, float probability,
+                             const Config& config) {
+    bool speechStart = probability >= config.speechThreshold;
+    bool speechKeep = probability >= config.silenceThreshold;
 
-    AppendPreRoll(frame.pcm);
+    AppendPreRoll(frame.pcm, PreRollSamples(config.preRollMs));
 
     if (state_ == State::Idle) {
         if (speechStart) {
             speechFrames_++;
-            if (speechFrames_ >= config_.startFrames) {
+            if (speechFrames_ >= config.startFrames) {
                 state_ = State::Speaking;
-                startMs_ = frame.timestamp_ms - config_.preRollMs;
+                startMs_ = frame.timestamp_ms - config.preRollMs;
 
                 SpeechEvent begin;
                 begin.type = SpeechEventType::Begin;
@@ -168,16 +183,16 @@ void VADWorker::ProcessFrame(const AudioFrame& frame, float probability) {
     }
 
     int endSilenceFrames =
-        config_.endSilenceMs / kFrameMs;
+        config.endSilenceMs / kFrameMs;
     bool silenceEnd = silenceFrames_ >= endSilenceFrames;
 
-    int maxDurationMs = config_.maxSpeechMs;
+    int maxDurationMs = config.maxSpeechMs;
     bool tooLong =
         (lastSpeechMs_ - startMs_) >= maxDurationMs;
 
     if (silenceEnd || tooLong) {
         int durationMs = static_cast<int>((lastSpeechMs_ - startMs_));
-        if (durationMs >= config_.minSpeechMs) {
+        if (durationMs >= config.minSpeechMs) {
             SpeechEvent end;
             end.type = SpeechEventType::End;
             end.timestamp_ms = frame.timestamp_ms;
@@ -190,7 +205,7 @@ void VADWorker::ProcessFrame(const AudioFrame& frame, float probability) {
             cancel.timestamp_ms = frame.timestamp_ms;
             if (speechEventQueue_) speechEventQueue_->Push(std::move(cancel));
             FCITX_DEBUG() << "[voice-input:vadworker] Utterance too short ("
-                          << durationMs << "ms < " << config_.minSpeechMs
+                          << durationMs << "ms < " << config.minSpeechMs
                           << "ms), cancelled";
         }
 
@@ -203,13 +218,11 @@ void VADWorker::ProcessFrame(const AudioFrame& frame, float probability) {
 }
 
 void VADWorker::AppendPreRoll(
-    const std::array<int16_t, kWindowSize>& pcm) {
+    const std::array<int16_t, kWindowSize>& pcm, size_t maxPreRollSamples) {
     for (auto sample : pcm) {
         preRoll_.push_back(sample);
     }
 
-    size_t maxPreRollSamples =
-        static_cast<size_t>(kSampleRate) * config_.preRollMs / 1000;
     while (preRoll_.size() > maxPreRollSamples) {
         preRoll_.pop_front();
     }

--- a/src/addon/vad/vad.h
+++ b/src/addon/vad/vad.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -50,11 +51,14 @@ public:
 
 private:
     void WorkerLoop();
-    void ProcessFrame(const AudioFrame& frame, float probability);
-    void AppendPreRoll(const std::array<int16_t, kWindowSize>& pcm);
+    void ProcessFrame(const AudioFrame& frame, float probability,
+                      const Config& config);
+    void AppendPreRoll(const std::array<int16_t, kWindowSize>& pcm,
+                       size_t maxPreRollSamples);
     void ResetSession();
 
     Config config_;
+    std::mutex configMutex_;  // SetConfig（主线程）与 worker 线程快照隔离
 
     std::unique_ptr<SileroVad> silero_;
 


### PR DESCRIPTION
## 背景

修复 [issue #14](https://github.com/devcxl/fcitx5-voice-input/issues/14) AI 深度代码审查中核实的 4 个并发/生命周期问题。

## 修复内容

### 1. [CRITICAL] 会话 worker 线程 use-after-free
- `openai_asr.cpp`: `End()` 启动 worker 时改用 `shared_from_this()` 保活会话对象——原实现捕获裸 `this`，reaper `JoinWithTimeout` 超时 `detach()` 后会话对象被析构，worker 线程随后访问已释放的 `apiEndpoint_`/`apiKey_`/`resultCb_` 等成员
- `openai_asr.cpp`: curl 注册 `XFERINFO` 进度回调，`Cancel()` 后立即中断在途 HTTP 传输，使 detach 路径几乎不可达
- `pipeline.cpp`: 结果/错误回调闭包捕获 `resultGuard_`（`shared_ptr<atomic<bool>>`），`Abort()` 置 false 后丢弃引擎 worker 线程的迟到回调——防止管线析构后回调访问已释放的 Pipeline

### 2. [HIGH] `sessionGenerationMap_`/`utteranceCounter_` 数据竞争
- 回调（引擎 worker 线程）、`AsrDispatcherLoop`（ASR 线程）、`Stop()`（主线程）三处无锁并发访问同一 `unordered_map`，属 UB
- 修复：新增 `sessionMapMutex_` 保护 map 的全部访问；`utteranceCounter_` 改 `std::atomic<uint64_t>`

### 3. [HIGH] 配置热更新与运行线程竞态
- `asrEngine_` 改 `shared_ptr<AsrEngine>` + `engineMutex_`：`SetAsrEngine` 锁内替换，ASR 线程每次取局部引用再调用，杜绝"旧引擎被 move 覆盖并析构时 ASR 线程正在 `StartSession()`"的 UAF
- `vad.cpp`: `config_` 增加 `configMutex_`，worker 每帧取配置快照，消除 `SetConfig` 主线程直写与 worker 逐帧读取的竞态

### 4. [MEDIUM] LLM 后处理无取消机制
- `LLMClient` 新增 `Cancel()` + curl `XFERINFO` 中断，`Pipeline::Stop()`/`Abort()` 联动取消在途请求，阻塞的 worker 线程立即解除
- LLM 流式/最终回调 push 前检查 `resultGuard_`

## 验证

- `cmake --build build -j$(nproc)` 通过（`voice-input-addon.so` 链接成功）
- 行为变更说明：取消后 worker 线程经 XFERINFO 中断快速退出，reaper 不再依赖 15s 超时 detach（仍保留作为极端兜底）；回调守卫使 Stop/Abort 后的迟到结果被丢弃（此前会被 push 进已清空的队列）

## 相关

- Issue: #14
- 其余问题（日志降级、配置权限、PA 停止阻塞、队列上限、WS 上限等）将在后续 PR 处理