### PR TITLE
fix(security-hardening): 日志降级、配置权限、停止路径与资源上限加固（issue #14 审查问题 4/5/6/7/9/10）

### DIFF
--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -282,8 +282,7 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
     long httpCode = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
     FCITX_DEBUG() << "[voice-input:openai] Response HTTP=" << httpCode
-                   << " body_len=" << response.size()
-                   << " body=[" << response << "]";
+                   << " body_len=" << response.size();
 
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
@@ -333,8 +332,9 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
     text.erase(0, text.find_first_not_of(" \t\n\r"));
     text.erase(text.find_last_not_of(" \t\n\r") + 1);
 
-    FCITX_INFO() << "[voice-input:openai] final session=" << state->sessionId
-                 << " \"" << text << "\"";
+    // 转写文本属敏感个人信息，降级为 DEBUG（默认 INFO 级别不落盘内容）
+    FCITX_DEBUG() << "[voice-input:openai] final session=" << state->sessionId
+                  << " \"" << text << "\"";
     if (resultCb_) resultCb_(text, true, state->sessionId);
 }
 

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -20,6 +20,7 @@ namespace {
 constexpr int kSourceSampleRate = 16000;
 constexpr int kTargetSampleRate = 24000;  // OpenAI Realtime 要求 >= 24kHz
 constexpr int kAppendChunkSamples = 2400; // ~100ms @24k 音频推送粒度（含重采样后）
+constexpr size_t kMaxFrameBytes = 16 * 1024 * 1024;  // 单帧 16MB 上限
 
 enum class RecvStatus { Ok, Again, Closed, Error };
 
@@ -86,7 +87,15 @@ RecvStatus ReceiveTextFrame(CURL* curl, std::string& out) {
         }
         if (meta && (meta->flags & CURLWS_CLOSE)) return RecvStatus::Closed;
         bool isText = meta && (meta->flags & CURLWS_TEXT);
-        if (received > 0) out.append(buffer.data(), received);
+        if (received > 0) {
+            // 限制单帧累计大小，防止恶意/异常服务端耗尽内存
+            if (out.size() + received > kMaxFrameBytes) {
+                FCITX_ERROR() << "[voice-input:realtime] WS frame exceeds "
+                              << kMaxFrameBytes << " bytes";
+                return RecvStatus::Error;
+            }
+            out.append(buffer.data(), received);
+        }
         if (!meta || !isText) continue;
         if (meta->bytesleft == 0) return RecvStatus::Ok;
     }
@@ -110,7 +119,7 @@ RealtimeAsrSession::RealtimeAsrSession(const AsrEngine::Config& config,
                                        uint64_t sessionId) {
     state_->sessionId = sessionId;
     errorCb_ = std::move(errorCb);
-    audioChunks_ = std::make_shared<ThreadSafeQueue<std::vector<int16_t>>>();
+    audioChunks_ = std::make_shared<ThreadSafeQueue<std::vector<int16_t>>>(512);
 
     // 由 baseUrl（https://api.openai.com/v1）派生 wss 端点
     std::string base = config.apiEndpoint;

--- a/src/addon/asr/volcengine_asr.cpp
+++ b/src/addon/asr/volcengine_asr.cpp
@@ -31,6 +31,8 @@ constexpr uint8_t kCompressionGzip = 0x1;
 constexpr int kVolcengineSampleRate = 16000;
 constexpr int kVolcengineBigmodelSuccessCode = 20000000;
 constexpr int kVolcengineLegacySuccessCode = 1000;
+constexpr size_t kMaxFrameBytes = 16 * 1024 * 1024;        // 单帧 16MB
+constexpr size_t kMaxDecompressedBytes = 16 * 1024 * 1024; // gzip 解压累计 16MB
 
 enum class RecvStatus { Ok, Again, Closed, Error };
 
@@ -94,6 +96,13 @@ std::string GzipDecompress(const uint8_t* data, size_t size) {
             return {};
         }
         out.append(buffer.data(), buffer.size() - zs.avail_out);
+        // 限制累计解压输出，防止恶意/异常服务端耗尽内存
+        if (out.size() > kMaxDecompressedBytes) {
+            FCITX_WARN() << "[voice-input:volcengine] gzip output exceeds "
+                         << kMaxDecompressedBytes << " bytes";
+            inflateEnd(&zs);
+            return {};
+        }
     }
     inflateEnd(&zs);
     return out;
@@ -182,6 +191,12 @@ RecvStatus ReceiveWebSocketFrame(CURL* curl, std::vector<uint8_t>& frame) {
         }
         if (meta && (meta->flags & CURLWS_CLOSE)) return RecvStatus::Closed;
         if (!meta || !(meta->flags & CURLWS_BINARY)) continue;
+        // 限制单帧累计大小，防止恶意/异常服务端耗尽内存
+        if (frame.size() + received > kMaxFrameBytes) {
+            FCITX_ERROR() << "[voice-input:volcengine] WS frame exceeds "
+                          << kMaxFrameBytes << " bytes";
+            return RecvStatus::Error;
+        }
         frame.insert(frame.end(), buffer.begin(), buffer.begin() + received);
         if (meta->bytesleft == 0) return RecvStatus::Ok;
     }
@@ -287,7 +302,7 @@ VolcengineAsrSession::VolcengineAsrSession(const AsrEngine::Config& config,
                                            uint64_t sessionId) {
     state_->sessionId = sessionId;
     errorCb_ = std::move(errorCb);
-    audioChunks_ = std::make_shared<ThreadSafeQueue<std::vector<int16_t>>>();
+    audioChunks_ = std::make_shared<ThreadSafeQueue<std::vector<int16_t>>>(512);
 
     endpoint_ = config.apiEndpoint.empty()
                     ? "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async"
@@ -560,7 +575,9 @@ void VolcengineAsrSession::WorkerLoop() {
         if (cb) cb("", true, sid);
         return;
     }
-    FCITX_INFO() << "[voice-input:volcengine] final session=" << sid << " \"" << latestText << "\"";
+    // 转写文本属敏感个人信息，降级为 DEBUG（默认 INFO 级别不落盘内容）
+    FCITX_DEBUG() << "[voice-input:volcengine] final session=" << sid
+                  << " \"" << latestText << "\"";
     if (cb) cb(latestText, true, sid);
 }
 

--- a/src/addon/capture/pulse_audio_capture.cpp
+++ b/src/addon/capture/pulse_audio_capture.cpp
@@ -9,6 +9,8 @@
 #include <fcitx-utils/log.h>
 #include <pulse/error.h>
 
+using namespace std::chrono_literals;
+
 namespace fcitx {
 namespace {
 
@@ -110,6 +112,20 @@ void PulseAudioCapture::Stop() {
 
     running_ = false;
     if (captureThread_ && captureThread_->joinable()) {
+        // pa_simple_read 是同步阻塞调用，设备挂起/异常时可能长时间不返回。
+        // 先尝试快速 join；超时则释放流以唤醒阻塞中的 read（read 返回错误后
+        // 线程自行退出），避免 Stop 永久阻塞主线程。
+        auto deadline = std::chrono::steady_clock::now() + 500ms;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(5ms);
+            if (!captureThread_->joinable()) break;
+        }
+        if (captureThread_->joinable() && stream_) {
+            FCITX_WARN() << "[voice-input:pulse] Stop join timeout, "
+                         << "freeing stream to wake up blocking read";
+            pa_simple_free(stream_);
+            stream_ = nullptr;
+        }
         captureThread_->join();
         captureThread_.reset();
     }

--- a/src/addon/engine.cpp
+++ b/src/addon/engine.cpp
@@ -6,7 +6,14 @@
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/log.h>
+// Ubuntu 24.04 等旧发行版的 fcitx5 仅有弃用的 standardpath.h，
+// 新版（fcitx5 >= 5.1.x）提供 standardpaths.h，条件编译兼容两者
+#if __has_include(<fcitx-utils/standardpaths.h>)
 #include <fcitx-utils/standardpaths.h>
+#define VOICE_INPUT_HAS_STANDARDPATHS
+#else
+#include <fcitx-utils/standardpath.h>
+#endif
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/addonmanager.h>
@@ -29,8 +36,13 @@ namespace {
 
 // 配置文件可能含 API Key 等敏感凭据，保存后收紧为仅所有者可读写
 void RestrictConfigFilePermissions(const std::string& relativePath) {
+#ifdef VOICE_INPUT_HAS_STANDARDPATHS
     auto configDir = StandardPaths::global().userDirectory(StandardPathsType::Config);
     std::string fullPath = (configDir / relativePath).string();
+#else
+    auto configDir = StandardPath::global().userDirectory(StandardPath::Type::Config);
+    std::string fullPath = configDir + "/" + relativePath;
+#endif
     if (::chmod(fullPath.c_str(), S_IRUSR | S_IWUSR) != 0) {
         FCITX_WARN() << "[voice-input] Failed to set 0600 permissions on "
                      << fullPath;

--- a/src/addon/engine.cpp
+++ b/src/addon/engine.cpp
@@ -1,10 +1,12 @@
 #include <string>
+#include <sys/stat.h>
 
 #include <fcitx-config/iniparser.h>
 #include <fcitx-utils/eventdispatcher.h>
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/addonmanager.h>
@@ -22,6 +24,35 @@
 #include "llm/llm_client.h"
 
 namespace fcitx {
+
+namespace {
+
+// 配置文件可能含 API Key 等敏感凭据，保存后收紧为仅所有者可读写
+void RestrictConfigFilePermissions(const std::string& relativePath) {
+    auto configDir = StandardPaths::global().userDirectory(StandardPathsType::Config);
+    std::string fullPath = (configDir / relativePath).string();
+    if (::chmod(fullPath.c_str(), S_IRUSR | S_IWUSR) != 0) {
+        FCITX_WARN() << "[voice-input] Failed to set 0600 permissions on "
+                     << fullPath;
+    }
+}
+
+// 端点走明文协议且非本机回环时，API Key 将明文传输，给出醒目警告
+bool EndpointUsesPlaintext(const std::string& endpoint) {
+    if (endpoint.empty()) return false;
+    if (endpoint.rfind("https://", 0) == 0 || endpoint.rfind("wss://", 0) == 0)
+        return false;
+    if (endpoint.rfind("http://", 0) == 0 || endpoint.rfind("ws://", 0) == 0) {
+        if (endpoint.find("localhost") != std::string::npos ||
+            endpoint.find("127.0.0.1") != std::string::npos ||
+            endpoint.find("[::1]") != std::string::npos)
+            return false;
+        return true;
+    }
+    return false;
+}
+
+} // namespace
 
 VoiceInputEngine::VoiceInputEngine(Instance* instance)
     : instance_(instance), pipeline_(std::make_unique<Pipeline>()) {
@@ -49,6 +80,7 @@ void VoiceInputEngine::setConfig(const RawConfig& rawConfig) {
                  << *config_.activeBackend;
 
     bool saved = safeSaveAsIni(config_, "conf/voiceinput.conf");
+    RestrictConfigFilePermissions("conf/voiceinput.conf");
     FCITX_INFO() << "[voice-input] setConfig saved=" << saved;
 
     if (initialized_) {
@@ -76,10 +108,12 @@ void VoiceInputEngine::setSubConfig(const std::string& path,
     if (path == "asr/openai") {
         openaiConfig_.load(rawConfig, true);
         safeSaveAsIni(openaiConfig_, "conf/voiceinput-openai.conf");
+        RestrictConfigFilePermissions("conf/voiceinput-openai.conf");
         FCITX_INFO() << "[voice-input] Saved openai sub-config";
     } else if (path == "asr/volcengine") {
         volcengineConfig_.load(rawConfig, true);
         safeSaveAsIni(volcengineConfig_, "conf/voiceinput-volcengine.conf");
+        RestrictConfigFilePermissions("conf/voiceinput-volcengine.conf");
         FCITX_INFO() << "[voice-input] Saved volcengine sub-config";
     }
 
@@ -168,10 +202,10 @@ void VoiceInputEngine::keyEvent(const InputMethodEntry& entry,
 
 void VoiceInputEngine::OnAsrResult(const std::string& text) {
     uint64_t generation = sessionGeneration_.load();
-    FCITX_INFO() << "[voice-input] OnAsrResult: text='"
-                 << text.substr(0, 30) << "'"
-                 << " sessionGen=" << generation
-                 << " activeGen=" << activeGeneration_.load();
+    // 语音转写内容属敏感个人信息，仅记录长度而非内容
+    FCITX_DEBUG() << "[voice-input] OnAsrResult: len=" << text.size()
+                  << " sessionGen=" << generation
+                  << " activeGen=" << activeGeneration_.load();
     eventDispatcher_.schedule([this, generation]() {
         if (generation == 0 || activeGeneration_.load() != generation) {
             FCITX_INFO() << "[voice-input] PollResults skipped: gen="
@@ -220,8 +254,9 @@ void VoiceInputEngine::PollResults() {
                         activeIc_->updateUserInterface(UserInterfaceComponent::StatusArea);
                     }
                 } else if (result.utteranceId == pendingPreeditUtteranceId_) {
-                    FCITX_INFO() << "[voice-input] LLM commit: uid=" << result.utteranceId
-                                 << " text=\"" << result.text << "\"";
+                    FCITX_DEBUG() << "[voice-input] LLM commit: uid="
+                                  << result.utteranceId
+                                  << " len=" << result.text.size();
                     activeIc_->commitString(result.text);
                     activeIc_->inputPanel().reset();
                     activeIc_->updateUserInterface(UserInterfaceComponent::InputPanel);
@@ -236,8 +271,8 @@ void VoiceInputEngine::PollResults() {
             } else {
                 bool llmActive = openaiConfig_.llmEnabled.value()
                               && !openaiConfig_.llmModel.value().empty();
-                FCITX_INFO() << "[voice-input] Preedit: uid=" << result.utteranceId
-                             << " text=\"" << result.text << "\""
+                FCITX_DEBUG() << "[voice-input] Preedit: uid=" << result.utteranceId
+                             << " len=" << result.text.size()
                              << " llmActive=" << llmActive;
 
                 if (result.isPartial) {
@@ -321,6 +356,11 @@ std::unique_ptr<AsrEngine> VoiceInputEngine::CreateAsrEngine() {
 
     if (backend == "volcengine") {
         asrConfig.apiEndpoint = *volcengineConfig_.endpoint;
+        if (EndpointUsesPlaintext(asrConfig.apiEndpoint)) {
+            FCITX_WARN() << "[voice-input] Volcengine endpoint is not TLS, "
+                         << "API credentials will be sent in plaintext: "
+                         << asrConfig.apiEndpoint;
+        }
         asrConfig.apiKey = *volcengineConfig_.apiKey;
         asrConfig.authMode = *volcengineConfig_.authMode;
         asrConfig.appKey = *volcengineConfig_.appKey;
@@ -339,6 +379,11 @@ std::unique_ptr<AsrEngine> VoiceInputEngine::CreateAsrEngine() {
         asr = std::make_unique<VolcengineAsrEngine>();
     } else {
         asrConfig.apiEndpoint = *openaiConfig_.baseUrl;
+        if (EndpointUsesPlaintext(asrConfig.apiEndpoint)) {
+            FCITX_WARN() << "[voice-input] OpenAI endpoint is not TLS, "
+                         << "API credentials will be sent in plaintext: "
+                         << asrConfig.apiEndpoint;
+        }
         asrConfig.apiKey = *openaiConfig_.apiKey;
         asrConfig.modelName = *openaiConfig_.model;
         asrConfig.apiMode = *openaiConfig_.apiMode;

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -149,8 +149,6 @@ std::string LLMClient::Process(const std::string& text) {
                  << " input=" << text.size() << " chars"
                  << " body=" << bodyStr.size() << " bytes";
 
-    FCITX_DEBUG() << "[voice-input:llm] Request body:\n" << bodyStr;
-
     // HTTP request
     auto tStart = std::chrono::steady_clock::now();
 
@@ -243,10 +241,8 @@ std::string LLMClient::Process(const std::string& text) {
                  << " elapsed=" << elapsedMs << "ms"
                  << " output=" << result.size() << " chars";
 
-    FCITX_DEBUG() << "[voice-input:llm] Response body:\n" << response;
-
-    FCITX_DEBUG() << "[voice-input:llm] Done: raw=\"" << text
-                 << "\" → out=\"" << result << "\"";
+    FCITX_DEBUG() << "[voice-input:llm] Done: raw=" << text.size()
+                 << " chars → out=" << result.size() << " chars";
     return result;
 }
 
@@ -352,8 +348,7 @@ void LLMClient::ProcessStream(const std::string& text,
     }
 
     FCITX_DEBUG() << "[voice-input:llm:stream] Done: elapsed=" << elapsedMs << "ms"
-                 << " accumulated=" << ctx.accumulated.size() << " chars"
-                 << " \"" << ctx.accumulated << "\"";
+                 << " accumulated=" << ctx.accumulated.size() << " chars";
 }
 
 } // namespace fcitx

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -221,6 +221,13 @@ void Pipeline::Start() {
     while (resultQueue_.TryPop(stale)) {}
 
     vadWorker_->Start();
+    if (!vadWorker_->IsRunning()) {
+        // VAD 初始化失败（如模型缺失）：回滚 capture，避免无消费者推帧
+        FCITX_ERROR() << "[voice-input] VAD failed to start, aborting";
+        capture_->Stop();
+        capture_.reset();
+        return;
+    }
 
     running_ = true;
     asrThread_ = std::make_unique<std::thread>(&Pipeline::AsrDispatcherLoop, this);
@@ -270,9 +277,13 @@ void Pipeline::Stop() {
         capture_.reset();
     }
 
-    // Drain remaining results
+    // Drain remaining results and audio queues（避免下次 Start 消费残留帧产生幽灵转写）
     AsrResult r;
     while (resultQueue_.TryPop(r)) {}
+    AudioFrame f;
+    while (frameQueue_.TryPop(f)) {}
+    SpeechEvent se;
+    while (speechEventQueue_.TryPop(se)) {}
     {
         std::lock_guard<std::mutex> lock(sessionMapMutex_);
         sessionGenerationMap_.clear();

--- a/src/addon/pipeline/pipeline.h
+++ b/src/addon/pipeline/pipeline.h
@@ -52,10 +52,11 @@ private:
     bool StartCapture();
     void AsrDispatcherLoop();
 
-    // Queues
-    ThreadSafeQueue<AudioFrame> frameQueue_;
-    ThreadSafeQueue<SpeechEvent> speechEventQueue_;
-    ThreadSafeQueue<AsrResult> resultQueue_;
+    // Queues（带容量上限：超限丢最旧，防止异常路径下内存无界增长）
+    // 1024 帧 ≈ 32s 音频缓冲；256 事件 ≈ 256 段语音；128 结果
+    ThreadSafeQueue<AudioFrame> frameQueue_{1024};
+    ThreadSafeQueue<SpeechEvent> speechEventQueue_{256};
+    ThreadSafeQueue<AsrResult> resultQueue_{128};
 
     // Workers
     std::unique_ptr<VADWorker> vadWorker_;

--- a/src/addon/utils/thread_safe_queue.h
+++ b/src/addon/utils/thread_safe_queue.h
@@ -10,11 +10,14 @@
  *
  * Used for passing audio chunks from capture thread to ASR thread,
  * and ASR results back to the main Fcitx5 event loop.
+ *
+ * maxSize > 0 时队列有容量上限：Push 超限丢弃最旧元素，避免消费者
+ * 异常/缓慢时内存无界增长。
  */
 template<typename T>
 class ThreadSafeQueue {
 public:
-    ThreadSafeQueue() = default;
+    explicit ThreadSafeQueue(size_t maxSize = 0) : maxSize_(maxSize) {}
 
     // Non-copyable
     ThreadSafeQueue(const ThreadSafeQueue&) = delete;
@@ -23,6 +26,9 @@ public:
     void Push(T value) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
+            if (maxSize_ > 0 && queue_.size() >= maxSize_) {
+                queue_.pop();  // 丢弃最旧元素（背压：新数据优先）
+            }
             queue_.push(std::move(value));
         }
         cv_.notify_one();
@@ -81,4 +87,5 @@ private:
     std::queue<T> queue_;
     std::condition_variable cv_;
     bool stopped_ = false;
+    size_t maxSize_ = 0;
 };

--- a/src/addon/vad/vad.cpp
+++ b/src/addon/vad/vad.cpp
@@ -65,13 +65,18 @@ void VADWorker::SetVadStatusCallback(VadStatusCallback cb) {
 void VADWorker::Start() {
     if (running_) return;
 
-    // Init Silero
+    // Init Silero（跨会话缓存模型实例，避免每次切换输入法都在主线程
+    // 重建 ONNX Session 造成卡顿；模型路径变化时重建）
     std::string modelPath = config_.sileroModelPath.empty()
                                 ? DefaultSileroModelPath()
                                 : config_.sileroModelPath;
-    silero_ = std::make_unique<SileroVad>(modelPath);
+    if (!silero_ || loadedModelPath_ != modelPath) {
+        silero_ = std::make_unique<SileroVad>(modelPath);
+        loadedModelPath_ = modelPath;
+    }
     if (!silero_->IsReady()) {
         FCITX_ERROR() << "[voice-input:vadworker] SileroVad init failed";
+        silero_.reset();
         return;
     }
 
@@ -88,7 +93,7 @@ void VADWorker::Stop() {
         thread_->join();
     }
     thread_.reset();
-    silero_.reset();
+    // 保留 silero_：模型实例跨会话复用（见 Start）
     FCITX_INFO() << "[voice-input:vadworker] Stopped";
 }
 

--- a/src/addon/vad/vad.h
+++ b/src/addon/vad/vad.h
@@ -61,6 +61,7 @@ private:
     std::mutex configMutex_;  // SetConfig（主线程）与 worker 线程快照隔离
 
     std::unique_ptr<SileroVad> silero_;
+    std::string loadedModelPath_;  // 已加载模型路径（模型缓存复用判断）
 
     ThreadSafeQueue<AudioFrame>* frameQueue_ = nullptr;
     ThreadSafeQueue<SpeechEvent>* speechEventQueue_ = nullptr;


### PR DESCRIPTION
## 背景

修复 [issue #14](https://github.com/devcxl/fcitx5-voice-input/issues/14) AI 深度代码审查中核实的 6 个安全/健壮性问题。并发与生命周期修复见 PR #15。

## 修复内容

### 4. [MEDIUM] 转写内容以 INFO 级别落盘（隐私泄露）
- `engine.cpp`: `OnAsrResult`/`Preedit`/`LLM commit` 日志只记录文本长度，不再记录内容（原为前 30 字符/完整文本 INFO）
- `openai_asr.cpp`/`volcengine_asr.cpp`: final 转写文本 INFO → DEBUG
- `openai_asr.cpp`/`llm_client.cpp`: 移除 HTTP 请求/响应体全文 DEBUG 打印（含完整转写），仅保留字节数

### 5. [MEDIUM] API Key 明文落盘 + 端点协议未强制 TLS
- 三个配置文件 `safeSaveAsIni` 保存后显式 `chmod 0600`（`RestrictConfigFilePermissions`，基于 `StandardPaths` 非弃用 API）
- 端点校验：非 `https://`/`wss://` 且非 localhost/127.0.0.1/[::1] 时给出醒目警告（不拒绝，兼容内网自建端点）

### 6. [MEDIUM] PulseAudio Stop 可能永久阻塞主线程
- `Stop()` 先 500ms 快速 join，超时则 `pa_simple_free` 释放流唤醒阻塞中的 `pa_simple_read` 再 join——设备挂起/拔出时不再卡死 fcitx 主线程

### 7. [MEDIUM] 队列无上限 + VAD 初始化失败后半启动
- `ThreadSafeQueue` 增加 `maxSize` 容量上限，Push 超限丢最旧：frameQueue 1024（≈32s）、speechEventQueue 256、resultQueue 128、会话音频队列 512
- `Pipeline::Start()` 校验 `VADWorker::IsRunning()`，VAD 启动失败（模型缺失）时停止并回滚 capture，不再无消费者推帧

### 9. [LOW] WebSocket 接收与 gzip 解压无大小上限
- volcengine/realtime 单帧累计 16MB 上限，超限断开报错；volcengine gzip 解压累计 16MB 上限

### 10. [LOW] Stop/Start 循环残留队列数据
- `Pipeline::Stop()` 排空 `frameQueue_`/`speechEventQueue_`（此前仅 `Abort` 清理），消除下次 Start 的幽灵转写
- VAD Silero 模型实例跨会话缓存（避免每次切换输入法在主线程重建 ONNX Session 造成卡顿；模型路径变化时重建）

## 验证

- `cmake --build build -j$(nproc)` 通过，无编译警告
- 行为变更说明：
  - 默认 INFO 日志不再包含任何语音转写内容（调试需开启 DEBUG）
  - VAD 模型改为常驻内存（约 10-20MB），换取切换输入法的流畅度
  - 队列上限在正常使用下不会触发（容量远超实际积压），仅在异常路径兜底