### PR TITLE
fix(capture): 回退跨线程 pa_simple_free，修复 free(): invalid pointer 崩溃

### DIFF
--- a/src/addon/capture/pulse_audio_capture.cpp
+++ b/src/addon/capture/pulse_audio_capture.cpp
@@ -9,8 +9,6 @@
 #include <fcitx-utils/log.h>
 #include <pulse/error.h>
 
-using namespace std::chrono_literals;
-
 namespace fcitx {
 namespace {
 
@@ -112,20 +110,11 @@ void PulseAudioCapture::Stop() {
 
     running_ = false;
     if (captureThread_ && captureThread_->joinable()) {
-        // pa_simple_read 是同步阻塞调用，设备挂起/异常时可能长时间不返回。
-        // 先尝试快速 join；超时则释放流以唤醒阻塞中的 read（read 返回错误后
-        // 线程自行退出），避免 Stop 永久阻塞主线程。
-        auto deadline = std::chrono::steady_clock::now() + 500ms;
-        while (std::chrono::steady_clock::now() < deadline) {
-            std::this_thread::sleep_for(5ms);
-            if (!captureThread_->joinable()) break;
-        }
-        if (captureThread_->joinable() && stream_) {
-            FCITX_WARN() << "[voice-input:pulse] Stop join timeout, "
-                         << "freeing stream to wake up blocking read";
-            pa_simple_free(stream_);
-            stream_ = nullptr;
-        }
+        // pa_simple_read 是同步阻塞调用，只能等线程退出后再释放流。
+        // 严禁在 join 前并发调用 pa_simple_free()：libpulse 对象不支持跨
+        // 线程并发访问，free 与阻塞中的 read 并发会构成 use-after-free/
+        // 堆损坏（曾引发 free(): invalid pointer 崩溃，见 PR #17）。
+        // 设备挂起时 Stop 可能因此阻塞——根治需改用 async API，见 issue。
         captureThread_->join();
         captureThread_.reset();
     }


### PR DESCRIPTION
## 背景

修复用户实测的崩溃：`free(): invalid pointer` → fcitx5 进程中止。根因来自 PR #16 的 PulseAudio Stop 改动。

## 根因

PR #16 在 `PulseAudioCapture::Stop()` 中新增"500ms 快速 join，超时则 `pa_simple_free()` 唤醒阻塞 read"的逻辑，存在两个致命缺陷：

1. **`joinable()` 不是存活检测**：`std::thread::joinable()` 在线程函数已结束、尚未 `join()` 时仍返回 `true`。等待循环里没有任何操作会改变它——因此**每次正常 Stop 都等满 500ms 并执行 `pa_simple_free()`**（日志从 `DelayedStop` 到警告相差约 501ms 已证实）。
2. **跨线程并发 free 构成 UAF/堆损坏**：`CaptureLoop` 线程可能正阻塞在 `pa_simple_read(stream_)`，主线程同时 `pa_simple_free(stream_)` 并写 `stream_ = nullptr`（另一处数据竞争）。libpulse 对象不支持跨线程并发访问，free 后对象立即失效。堆被破坏后潜伏，下一次任意内存操作（崩溃栈中的 `ClearUI` → `InputPanel::reset` → `Text::clear`，实为检测点）触发 `free(): invalid pointer`。

## 修复

恢复 9b062b8 之前的安全顺序：

```
running_ = false → captureThread_->join() → pa_simple_free(stream_)
```

仅在 capture 线程退出后释放流，消除并发访问与 UAF。

**已知代价**：设备挂起时 `pa_simple_read` 不返回，`Stop()` 可能阻塞主线程（旧有行为）。`libpulse-simple` 没有安全的跨线程取消接口，根治需改为 async API（`pa_threaded_mainloop` + `pa_stream`），单独跟踪。

## 验证

- `cmake --build` 通过，0 警告；diff 仅 1 文件（+5/-16）
- 复测建议：连续 activate/deactivate 多次观察无 `Stop join timeout` 日志、无崩溃
- 长期验证：ASan 构建 + 暂停 PulseAudio 服务后 deactivate 复现/验证

## 相关

- 引入回归：PR #16（9b062b8）
- 后续：async PulseAudio 改造（解决设备挂起时 Stop 阻塞）