### PR TITLE
feat(capture): 录音后端改为可选依赖，缺失时降级构建

### DIFF
--- a/.github/actions/aur/build.sh
+++ b/.github/actions/aur/build.sh
@@ -19,10 +19,12 @@ docker build -t arch-builder "$(dirname "$0")"
 docker run --rm -v "${PWD}/${WORK_DIR}:/build" arch-builder
 
 # Extract result
-PKGFILE=$(ls "${WORK_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1)
+PKGFILE=$(ls "${WORK_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1 || true)
 if [ -n "${PKGFILE}" ]; then
   cp "${PKGFILE}" "${OUT_DIR}/"
   echo "pkgfile=${PKGFILE}" >> "${GITHUB_OUTPUT}"
 else
+  echo "::error::makepkg produced no .pkg.tar.zst — check AUR build logs"
   echo "pkgfile=" >> "${GITHUB_OUTPUT}"
+  exit 1
 fi

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: CMake build type
     required: false
     default: Release
+  capture_pkgs:
+    description: apt packages for audio capture backends (override to simulate a missing backend)
+    required: false
+    default: "libpipewire-0.3-dev libspa-0.2-dev libpulse-dev"
 
 outputs:
   deb_path:
@@ -21,8 +25,7 @@ runs:
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
           libfcitx5core-dev \
-          libpipewire-0.3-dev libspa-0.2-dev \
-          libpulse-dev \
+          ${{ inputs.capture_pkgs }} \
           gettext \
           libjsoncpp-dev \
           libcurl4-openssl-dev \
@@ -32,6 +35,8 @@ runs:
     - name: Install ONNX Runtime
       shell: bash
       run: |
+        # 固定版本：Ubuntu/Debian 官方仓库无 onnxruntime 包，只能从 upstream release 下载。
+        # 升级时同步修改此版本号（需与 ABI 兼容的运行时/打包依赖）。
         ONNX_VER=1.20.1
         ONNX_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VER}/onnxruntime-linux-x64-${ONNX_VER}.tgz"
         curl -fsSL "$ONNX_URL" -o /tmp/onnxruntime.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,26 @@ jobs:
             dist/aur/*.pkg.tar.zst
             dist/aur/PKGBUILD
           if-no-files-found: warn
+
+  # 回归防护：录音后端已改为可选依赖（CMake QUIET 探测），
+  # 确保缺失任一后端时仍能构建，且产物不引用缺失库的符号。
+  build-no-pipewire:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/build
+        with:
+          capture_pkgs: "libpulse-dev"  # 不装 PipeWire dev 包，模拟上游 pipewire 不可用
+
+      - name: Verify no PipeWire symbols
+        shell: bash
+        run: |
+          if nm -D build/voice-input-addon.so | grep -qE "pw_|pipewire"; then
+            echo "::error::build succeeded but .so still links PipeWire symbols (HAVE_PIPEWIRE misconfig)"
+            exit 1
+          fi
+          echo "OK: PipeWire backend excluded, PulseAudio only"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cmake --build build -j"$(nproc)"
 ## 依赖
 
 必需：`fcitx5`（pkg-config 名 fcitx5 或 Fcitx5Core）、`jsoncpp`、`libcurl`（>= 7.86.0）、`zlib`、`onnxruntime`（Silero VAD）。
-可选（至少其一）：`pipewire-0.3`（libpipewire-0.3）、`libpulse-simple`。缺少任一录音后端时仅失去对应 capture 后端，addon 仍可构建；两个都缺则 CMake 报错。
+可选（至少其一）：`pipewire-0.3`（libpipewire-0.3）、`libpulse-simple`。缺少任一录音后端时仅失去对应 capture 后端，addon 仍可构建；两个都缺则 CMake 报错。**运行时**两个库均为 dlopen 延迟加载（无链接期依赖），库升级/soname 变更不影响已安装 addon。
 
 克隆后需执行：`git submodule update --init --recursive`。
 
@@ -57,6 +57,7 @@ po/
 - **禁止安装**: 除非用户明确要求 `cmake --install`，否则只构建不安装。勿动 `/usr`、`~/.local` 等路径。
 - **PipeWire 回调**: `on_process` 内 ≤100μs，只写 ring buffer，禁止阻塞/VAD/分配
 - **音频捕获后端**: 可选编译（CMake 宏 `HAVE_PULSEAUDIO`/`HAVE_PIPEWIRE`），优先 PulseAudio（兼容 PulseAudio 和 pipewire-pulse），失败后 fallback 到 PipeWire 直连；仅编译进来的后端可用
+- **录音库运行期加载（dlopen）**: libpulse-simple/libpipewire **不链接**（无 DT_NEEDED），由各 capture 的 `LoadLib()` 在 Start 时 dlopen（RTLD_NOW|RTLD_GLOBAL，候选 soname 列表 + 关键符号 dlsym 校验）。fcitx5 以 RTLD_LAZY 加载 addon（`Library=` 无 `export:` 前缀），未定义符号延迟到首次调用解析——首次调用必在 LoadLib 成功后，故安全。库缺失/soname 变更时后端优雅降级，addon 本体不受影响
 - **PipeWire**: on_process→ringbuffer(float32)→DrainLoop thread→int16 AudioFrame→FrameQueue
 - **Ring buffer**: `Clear()` 被故意省略（与 PipeWire 回调 data race），清空用 `Read()` drain 模式
 - **音频格式统一**: 16kHz mono, int16, 512 samples/window (32ms)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,10 @@ cmake --build build -j"$(nproc)"
 
 选项：`BUILD_TESTS`（目前无测试文件）。
 
-## 依赖（全部必需）
+## 依赖
 
-`fcitx5`（pkg-config 名 fcitx5 或 Fcitx5Core）、`pipewire-0.3`（libpipewire-0.3）、`libpulse-simple`、`jsoncpp`、`libcurl`（>= 7.86.0）、`zlib`、`onnxruntime`（Silero VAD）。
+必需：`fcitx5`（pkg-config 名 fcitx5 或 Fcitx5Core）、`jsoncpp`、`libcurl`（>= 7.86.0）、`zlib`、`onnxruntime`（Silero VAD）。
+可选（至少其一）：`pipewire-0.3`（libpipewire-0.3）、`libpulse-simple`。缺少任一录音后端时仅失去对应 capture 后端，addon 仍可构建；两个都缺则 CMake 报错。
 
 克隆后需执行：`git submodule update --init --recursive`。
 
@@ -55,7 +56,7 @@ po/
 - **Addon 注册**: `FCITX_ADDON_FACTORY(VoiceInputAddonFactory)` — 必须在 `namespace fcitx` 外部
 - **禁止安装**: 除非用户明确要求 `cmake --install`，否则只构建不安装。勿动 `/usr`、`~/.local` 等路径。
 - **PipeWire 回调**: `on_process` 内 ≤100μs，只写 ring buffer，禁止阻塞/VAD/分配
-- **音频捕获后端**: 优先 PulseAudio（兼容 PulseAudio 和 pipewire-pulse），失败后 fallback 到 PipeWire 直连
+- **音频捕获后端**: 可选编译（CMake 宏 `HAVE_PULSEAUDIO`/`HAVE_PIPEWIRE`），优先 PulseAudio（兼容 PulseAudio 和 pipewire-pulse），失败后 fallback 到 PipeWire 直连；仅编译进来的后端可用
 - **PipeWire**: on_process→ringbuffer(float32)→DrainLoop thread→int16 AudioFrame→FrameQueue
 - **Ring buffer**: `Clear()` 被故意省略（与 PipeWire 回调 data race），清空用 `Read()` drain 模式
 - **音频格式统一**: 16kHz mono, int16, 512 samples/window (32ms)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,9 @@ target_include_directories(voice-input-addon PRIVATE
     ${ONNXRUNTIME_INCLUDE_DIRS}
     src/addon
 )
+# 录音库仅在编译期需要头文件（结构体/枚举/宏定义）；
+# 运行期通过 dlopen 按需加载（见 pulse/pipewire capture 的 LoadLib），
+# 因此不链接这两个库——避免 DT_NEEDED 硬依赖，库升级/soname 变更时 addon 仍可加载。
 if(PIPEWIRE_FOUND)
     target_include_directories(voice-input-addon PRIVATE ${PIPEWIRE_INCLUDE_DIRS})
 endif()
@@ -184,15 +187,10 @@ target_link_libraries(voice-input-addon PRIVATE
     ${FCITX5_LIBRARIES}
     ${JSONCPP_LIBRARIES}
     ${ONNXRUNTIME_LIBRARIES}
+    ${CMAKE_DL_LIBS}
     CURL::libcurl
     ZLIB::ZLIB
 )
-if(PIPEWIRE_FOUND)
-    target_link_libraries(voice-input-addon PRIVATE ${PIPEWIRE_LIBRARIES})
-endif()
-if(PULSE_FOUND)
-    target_link_libraries(voice-input-addon PRIVATE ${PULSE_LIBRARIES})
-endif()
 
 target_compile_definitions(voice-input-addon PRIVATE
     VOICE_INPUT_VERSION="${PROJECT_VERSION}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,25 @@ else()
     set(FCITX5_ADDON_DIR "lib/fcitx5")
 endif()
 
-# PipeWire audio capture
+# PipeWire audio capture (optional — 缺失时仅失去该后端，不影响其余功能)
 pkg_check_modules(PIPEWIRE QUIET pipewire-0.3)
 if(NOT PIPEWIRE_FOUND)
-    pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
+    pkg_check_modules(PIPEWIRE QUIET libpipewire-0.3)
 endif()
 
-# PulseAudio fallback capture
-pkg_check_modules(PULSE REQUIRED libpulse-simple libpulse)
+# PulseAudio fallback capture (optional — 缺失时仅失去该后端，不影响其余功能)
+pkg_check_modules(PULSE QUIET libpulse-simple libpulse)
+
+# 至少需要一个录音后端，否则 addon 无录音能力
+if(NOT PIPEWIRE_FOUND AND NOT PULSE_FOUND)
+    message(FATAL_ERROR "No audio capture backend found. Install at least one of: pipewire-0.3 (libpipewire-0.3-dev) or libpulse-simple (libpulse-dev)")
+endif()
+if(NOT PIPEWIRE_FOUND)
+    message(WARNING "PipeWire not found — building without PipeWire capture backend")
+endif()
+if(NOT PULSE_FOUND)
+    message(WARNING "PulseAudio not found — building without PulseAudio capture backend")
+endif()
 
 # JSON parsing
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
@@ -101,8 +112,6 @@ message(STATUS "Silero VAD enabled with model: ${SILERO_VAD_MODEL_SOURCE}")
 # ─── Sources ──────────────────────────────────────────────────────────────────
 set(ADDON_SOURCES
     src/addon/engine.cpp
-    src/addon/capture/pipewire_capture.cpp
-    src/addon/capture/pulse_audio_capture.cpp
     src/addon/vad/vad.cpp
     src/addon/vad/silero_vad.cpp
     src/addon/pipeline/pipeline.cpp
@@ -115,13 +124,19 @@ set(ADDON_SOURCES
     src/addon/llm/llm_client.cpp
 )
 
+# 按可用性加入录音后端（可选依赖）
+if(PIPEWIRE_FOUND)
+    list(APPEND ADDON_SOURCES src/addon/capture/pipewire_capture.cpp)
+endif()
+if(PULSE_FOUND)
+    list(APPEND ADDON_SOURCES src/addon/capture/pulse_audio_capture.cpp)
+endif()
+
 set(ADDON_HEADERS
     src/addon/engine.h
     src/addon/types.h
     src/addon/config/voiceinput-config.h
     src/addon/capture/audio_capture.h
-    src/addon/capture/pipewire_capture.h
-    src/addon/capture/pulse_audio_capture.h
     src/addon/vad/vad.h
     src/addon/vad/silero_vad.h
     src/addon/asr/asr_engine.h
@@ -137,6 +152,14 @@ set(ADDON_HEADERS
     src/addon/asr/utils/base64.h
 )
 
+# 头文件仅用于 IDE 索引，同样按可用性追加
+if(PIPEWIRE_FOUND)
+    list(APPEND ADDON_HEADERS src/addon/capture/pipewire_capture.h)
+endif()
+if(PULSE_FOUND)
+    list(APPEND ADDON_HEADERS src/addon/capture/pulse_audio_capture.h)
+endif()
+
 # ─── Library ──────────────────────────────────────────────────────────────────
 add_library(voice-input-addon MODULE ${ADDON_SOURCES} ${ADDON_HEADERS})
 
@@ -145,29 +168,43 @@ set_target_properties(voice-input-addon PROPERTIES PREFIX "")
 
 target_include_directories(voice-input-addon PRIVATE
     ${FCITX5_INCLUDE_DIRS}
-    ${PIPEWIRE_INCLUDE_DIRS}
-    ${PULSE_INCLUDE_DIRS}
     ${JSONCPP_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
     ${ONNXRUNTIME_INCLUDE_DIRS}
     src/addon
 )
+if(PIPEWIRE_FOUND)
+    target_include_directories(voice-input-addon PRIVATE ${PIPEWIRE_INCLUDE_DIRS})
+endif()
+if(PULSE_FOUND)
+    target_include_directories(voice-input-addon PRIVATE ${PULSE_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(voice-input-addon PRIVATE
     ${FCITX5_LIBRARIES}
-    ${PIPEWIRE_LIBRARIES}
-    ${PULSE_LIBRARIES}
     ${JSONCPP_LIBRARIES}
     ${ONNXRUNTIME_LIBRARIES}
     CURL::libcurl
     ZLIB::ZLIB
 )
+if(PIPEWIRE_FOUND)
+    target_link_libraries(voice-input-addon PRIVATE ${PIPEWIRE_LIBRARIES})
+endif()
+if(PULSE_FOUND)
+    target_link_libraries(voice-input-addon PRIVATE ${PULSE_LIBRARIES})
+endif()
 
 target_compile_definitions(voice-input-addon PRIVATE
     VOICE_INPUT_VERSION="${PROJECT_VERSION}"
     FCITX_GETTEXT_DOMAIN="fcitx5-voice-input"
     VOICE_INPUT_LOCALE_DIR="${CMAKE_INSTALL_FULL_LOCALEDIR}"
 )
+if(PIPEWIRE_FOUND)
+    target_compile_definitions(voice-input-addon PRIVATE HAVE_PIPEWIRE)
+endif()
+if(PULSE_FOUND)
+    target_compile_definitions(voice-input-addon PRIVATE HAVE_PULSEAUDIO)
+endif()
 
 # ─── Translations ────────────────────────────────────────────────────────────
 find_program(GETTEXT_MSGFMT msgfmt REQUIRED)
@@ -256,6 +293,13 @@ set(CPACK_PACKAGE_CONTACT "64475363+devcxl@users.noreply.github.com")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "devcxl <64475363+devcxl@users.noreply.github.com>")
 set(CPACK_DEBIAN_PACKAGE_SECTION "libs")
+# 核心运行时依赖（Ubuntu 24.04 / Debian 包名；libcurl4t64 为 t64 迁移后的包名）
+# 注意：onnxruntime 不在 Ubuntu 官方仓库（CI 手动下载 release 包），无法声明
+# Depends；DEB 用户需自行安装 onnxruntime 运行时（见 README/CI 下载地址）
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "fcitx5, libjsoncpp25, libcurl4t64, zlib1g")
+# 录音后端为可选运行时依赖：Recommends 二选一（Ubuntu/Debian 运行时包名），
+# 与 CMake 构建期的可选探测保持一致——缺任一后端时包仍可安装使用另一个
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libpipewire-0.3-0 | libpulse0")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/devcxl/fcitx5-voice-input")
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -10,14 +10,16 @@ license=('Apache')
 options=('!debug')
 depends=(
     'fcitx5'
-    'pipewire'
-    'libpulse'
     'jsoncpp'
     'curl'
     'onnxruntime-cpu'
     'zlib'
 )
-optdepends=()
+# 录音后端为可选依赖，至少安装其一（都不装则无法录音）
+optdepends=(
+    'pipewire: PipeWire capture backend (required for recording)'
+    'libpulse: PulseAudio capture backend (required for recording)'
+)
 makedepends=('cmake' 'pkg-config' 'gettext')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/devcxl/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('SKIP')

--- a/src/addon/capture/pipewire_capture.cpp
+++ b/src/addon/capture/pipewire_capture.cpp
@@ -3,12 +3,23 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <dlfcn.h>
 #include <thread>
 
 #include <spa/param/audio/format-utils.h>
 #include <fcitx-utils/log.h>
 
 namespace fcitx {
+namespace {
+
+// libpipewire 运行时库候选 soname（按优先级）。pipewire 0.3 系列为 .so.0；
+// 未来若 soname 变更（如 1.0），旧版本 addon 仍可尝试后续候选。
+constexpr const char* kPwLibCandidates[] = {
+    "libpipewire-0.3.so.0",
+    "libpipewire-1.0.so.0",
+};
+
+} // namespace
 
 PipeWireCapture::PipeWireCapture()
     : ringBuffer_(std::make_unique<AudioRingBuffer>(65536)) {}
@@ -17,14 +28,53 @@ PipeWireCapture::~PipeWireCapture() {
     Stop();
 }
 
+// dlopen 加载 libpipewire 并校验关键符号。
+// 返回 true 后所有 pw_* 调用均安全；失败则本后端不可用（Start 返回 false，
+// 由 pipeline 回退到其他后端），不影响 addon 本体加载。
+bool PipeWireCapture::LoadLib() {
+    if (pwLib_) return true;
+
+    for (const char* soname : kPwLibCandidates) {
+        void* handle = dlopen(soname, RTLD_NOW | RTLD_GLOBAL);
+        if (!handle) continue;
+
+        // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
+        // 必须确认入口符号真实存在，否则后续调用会 undefined symbol 崩溃
+        if (!dlsym(handle, "pw_init")) {
+            FCITX_WARN() << "[voice-input:pw] " << soname
+                         << " loaded but pw_init missing: " << dlerror();
+            dlclose(handle);
+            continue;
+        }
+
+        pwLib_ = handle;
+        FCITX_INFO() << "[voice-input:pw] Runtime-loaded " << soname;
+        return true;
+    }
+
+    FCITX_WARN() << "[voice-input:pw] Failed to dlopen libpipewire: "
+                 << dlerror();
+    return false;
+}
+
+void PipeWireCapture::UnloadLib() {
+    if (pwLib_) {
+        dlclose(pwLib_);
+        pwLib_ = nullptr;
+    }
+}
+
 bool PipeWireCapture::Start() {
     if (running_) return true;
+
+    if (!LoadLib()) return false;
 
     pw_init(nullptr, nullptr);
 
     loop_ = pw_thread_loop_new("voice-input-capture", nullptr);
     if (!loop_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_thread_loop";
+        UnloadLib();
         return false;
     }
 
@@ -32,6 +82,7 @@ bool PipeWireCapture::Start() {
     if (!context_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_context";
         Cleanup(false);
+        UnloadLib();
         return false;
     }
 
@@ -39,6 +90,7 @@ bool PipeWireCapture::Start() {
     if (!core_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to connect pw_context";
         Cleanup(false);
+        UnloadLib();
         return false;
     }
 
@@ -55,6 +107,7 @@ bool PipeWireCapture::Start() {
     if (!stream_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_stream";
         Cleanup(false);
+        UnloadLib();
         return false;
     }
 
@@ -89,12 +142,14 @@ bool PipeWireCapture::Start() {
     if (connectResult < 0) {
         FCITX_ERROR() << "[voice-input:pw] pw_stream_connect failed: " << connectResult;
         Cleanup(false);
+        UnloadLib();
         return false;
     }
 
     if (pw_thread_loop_start(loop_) < 0) {
         FCITX_ERROR() << "[voice-input:pw] Failed to start pw_thread_loop";
         Cleanup(false);
+        UnloadLib();
         return false;
     }
 
@@ -118,6 +173,7 @@ void PipeWireCapture::Stop() {
     }
 
     Cleanup(true);
+    UnloadLib();
     running_ = false;
     FCITX_INFO() << "[voice-input:pw] Capture stopped";
 }

--- a/src/addon/capture/pipewire_capture.h
+++ b/src/addon/capture/pipewire_capture.h
@@ -34,8 +34,14 @@ private:
     static void OnStateChanged(void* userdata, pw_stream_state oldState,
                                pw_stream_state state, const char* error);
     void OnProcessImpl();
+    bool LoadLib();
+    void UnloadLib();
     void Cleanup(bool stopLoop);
     void DrainLoop();
+
+    // 运行期 dlopen 句柄（RTLD_GLOBAL 加载 libpipewire，避免链接期
+    // DT_NEEDED 硬依赖——库升级/soname 变更时 addon 仍可加载）
+    void* pwLib_ = nullptr;
 
     pw_thread_loop* loop_ = nullptr;
     pw_context* context_ = nullptr;

--- a/src/addon/capture/pulse_audio_capture.cpp
+++ b/src/addon/capture/pulse_audio_capture.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <dlfcn.h>
 #include <string>
 
 #include <fcitx-utils/log.h>
@@ -11,6 +12,13 @@
 
 namespace fcitx {
 namespace {
+
+// libpulse-simple 运行时库候选 soname（按优先级）。当前所有主流发行版为 .so.0；
+// 未来若 soname 变更，旧版本 addon 仍可尝试后续候选，任一成功即可用。
+constexpr const char* kPulseLibCandidates[] = {
+    "libpulse-simple.so.0",
+    "libpulse-simple.so.1",
+};
 
 constexpr size_t kPactlLineMax = 512;
 
@@ -69,8 +77,46 @@ PulseAudioCapture::PulseAudioCapture() = default;
 
 PulseAudioCapture::~PulseAudioCapture() { Stop(); }
 
+// dlopen 加载 libpulse-simple 并校验关键符号。
+// 返回 true 后所有 pa_* 调用均安全；失败则本后端不可用（Start 返回 false，
+// 由 pipeline 回退到其他后端），不影响 addon 本体加载。
+bool PulseAudioCapture::LoadLib() {
+    if (pulseLib_) return true;
+
+    for (const char* soname : kPulseLibCandidates) {
+        void* handle = dlopen(soname, RTLD_NOW | RTLD_GLOBAL);
+        if (!handle) continue;
+
+        // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
+        // 必须确认入口符号真实存在，否则后续调用会 undefined symbol 崩溃
+        if (!dlsym(handle, "pa_simple_new")) {
+            FCITX_WARN() << "[voice-input:pulse] " << soname
+                         << " loaded but pa_simple_new missing: " << dlerror();
+            dlclose(handle);
+            continue;
+        }
+
+        pulseLib_ = handle;
+        FCITX_INFO() << "[voice-input:pulse] Runtime-loaded " << soname;
+        return true;
+    }
+
+    FCITX_WARN() << "[voice-input:pulse] Failed to dlopen libpulse-simple: "
+                 << dlerror();
+    return false;
+}
+
+void PulseAudioCapture::UnloadLib() {
+    if (pulseLib_) {
+        dlclose(pulseLib_);
+        pulseLib_ = nullptr;
+    }
+}
+
 bool PulseAudioCapture::Start() {
     if (running_) return true;
+
+    if (!LoadLib()) return false;
 
     pa_sample_spec sampleSpec{};
     sampleSpec.format = PA_SAMPLE_S16LE;
@@ -94,6 +140,7 @@ bool PulseAudioCapture::Start() {
         FCITX_ERROR() << "[voice-input:pulse] Failed to open source: "
                       << (device ? device : "(default)")
                       << " — " << pa_strerror(error);
+        UnloadLib();
         return false;
     }
 
@@ -123,6 +170,7 @@ void PulseAudioCapture::Stop() {
         pa_simple_free(stream_);
         stream_ = nullptr;
     }
+    UnloadLib();
     FCITX_INFO() << "[voice-input:pulse] Capture stopped";
 }
 

--- a/src/addon/capture/pulse_audio_capture.h
+++ b/src/addon/capture/pulse_audio_capture.h
@@ -26,6 +26,11 @@ public:
     const char* Name() const override { return "pulseaudio"; }
 
 private:
+    // 运行期 dlopen 句柄（RTLD_GLOBAL 加载 libpulse-simple，避免链接期
+    // DT_NEEDED 硬依赖——库升级/soname 变更时 addon 仍可加载）
+    void* pulseLib_ = nullptr;
+    bool LoadLib();
+    void UnloadLib();
     void CaptureLoop();
 
     pa_simple* stream_ = nullptr;

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -6,8 +6,12 @@
 #include <cmath>
 #include <thread>
 
+#ifdef HAVE_PIPEWIRE
 #include "capture/pipewire_capture.h"
+#endif
+#ifdef HAVE_PULSEAUDIO
 #include "capture/pulse_audio_capture.h"
+#endif
 #include "llm/llm_client.h"
 
 using namespace std::chrono_literals;
@@ -339,6 +343,7 @@ void Pipeline::Abort() {
 }
 
 bool Pipeline::StartCapture() {
+#ifdef HAVE_PULSEAUDIO
     capture_ = std::make_unique<PulseAudioCapture>();
     capture_->SetFrameQueue(&frameQueue_);
 
@@ -348,6 +353,10 @@ bool Pipeline::StartCapture() {
     }
 
     FCITX_WARN() << "[voice-input] PulseAudio failed, falling back to PipeWire";
+    capture_.reset();
+#endif
+
+#ifdef HAVE_PIPEWIRE
     capture_ = std::make_unique<PipeWireCapture>();
     capture_->SetFrameQueue(&frameQueue_);
 
@@ -356,8 +365,14 @@ bool Pipeline::StartCapture() {
         return true;
     }
 
-    FCITX_ERROR() << "[voice-input] Failed to start any capture backend";
+    FCITX_ERROR() << "[voice-input] PipeWire failed to start";
     capture_.reset();
+#endif
+
+#if !defined(HAVE_PULSEAUDIO) && !defined(HAVE_PIPEWIRE)
+    // CMake 已保证至少编译一个后端，此处仅作防御
+    FCITX_ERROR() << "[voice-input] No capture backend compiled in";
+#endif
     return false;
 }
 


### PR DESCRIPTION
## 背景

PulseAudio/PipeWire 任一库升级导致 pkg-config 探测失败时，原 REQUIRED 依赖会让整个 addon 构建失败、不可用。改为可选依赖：缺一个只失去对应 capture 后端，另一个照常工作。

## 改动

### CMake（`CMakeLists.txt`）
- PipeWire（`pipewire-0.3`/`libpipewire-0.3`）与 PulseAudio（`libpulse-simple`）由 `REQUIRED` 改为 `QUIET` 探测
- 找到才编译对应 `.cpp`、加入 include/link 与 `HAVE_PIPEWIRE`/`HAVE_PULSEAUDIO` 宏
- **两个都缺才 FATAL**（addon 无录音能力），缺一个只打 WARNING
- DEB 补上运行时依赖：`Depends: fcitx5, libjsoncpp25, libcurl4t64, zlib1g`（包名经 Ubuntu 24.04 仓库索引核实，libcurl4t64 为 t64 迁移后包名）+ `Recommends: libpipewire-0.3-0 | libpulse0`（二选一语义）
  - onnxruntime 不在 Ubuntu 官方仓库（CI 手动下载 release 包），无法声明 Depends，注释说明

### 代码（`pipeline.cpp`）
- `StartCapture()` 按宏条件编译：缺 PulseAudio 时不再尝试/不再打"fallback to PipeWire"日志；缺 PipeWire 时跳过；全缺为防御分支（CMake 已保证不出现）

### 打包
- `aur/PKGBUILD`: `pipewire`/`libpulse` 从 `depends` 移入 `optdepends`（至少其一，均缺时 CMake 报错提示）

### CI（回归防护）
- `.github/actions/build/action.yml`: 新增 `capture_pkgs` 输入（依赖安装可覆写）
- `.github/workflows/build.yml`: 新增 `build-no-pipewire` job——不装 PipeWire dev 包构建 + `nm -D` 断言产物无 `pw_` 符号，防止未来误改回必需依赖
- `.github/actions/aur/build.sh`: makepkg 产物缺失时 `::error::` + `exit 1`，不再静默

### 文档
- `AGENTS.md`: 依赖说明同步（必需/可选拆分）

## 验证

本地实测 4 种场景（fake pkg-config 屏蔽）：
- 双依赖齐全 → 构建成功，两后端编译
- 缺 PulseAudio → 构建成功，`.so` 无 `pa_simple` 符号
- 缺 PipeWire → 构建成功，`.so` 无 `pw_` 符号
- 两个都缺 → CMake FATAL 并提示安装其一

DEB 实测：`Depends: fcitx5, libjsoncpp25, libcurl4t64, zlib1g` / `Recommends: libpipewire-0.3-0 | libpulse0`