### PR TITLE
fix(build): 链接录音后端库，修复 addon 加载失败 (undefined symbol pw_properties_new)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,9 +173,9 @@ target_include_directories(voice-input-addon PRIVATE
     ${ONNXRUNTIME_INCLUDE_DIRS}
     src/addon
 )
-# 录音库仅在编译期需要头文件（结构体/枚举/宏定义）；
-# 运行期通过 dlopen 按需加载（见 pulse/pipewire capture 的 LoadLib），
-# 因此不链接这两个库——避免 DT_NEEDED 硬依赖，库升级/soname 变更时 addon 仍可加载。
+# 录音后端直接调用 pw_*/pa_* 符号（未走 dlsym），必须链接对应库才能解析；
+# 否则 addon 加载时报 undefined symbol（如 pw_properties_new），整个插件无法加载。
+# 按可用性条件链接：缺失的后端不编译、不链接。
 if(PIPEWIRE_FOUND)
     target_include_directories(voice-input-addon PRIVATE ${PIPEWIRE_INCLUDE_DIRS})
 endif()
@@ -191,6 +191,12 @@ target_link_libraries(voice-input-addon PRIVATE
     CURL::libcurl
     ZLIB::ZLIB
 )
+if(PIPEWIRE_FOUND)
+    target_link_libraries(voice-input-addon PRIVATE ${PIPEWIRE_LIBRARIES})
+endif()
+if(PULSE_FOUND)
+    target_link_libraries(voice-input-addon PRIVATE ${PULSE_LIBRARIES})
+endif()
 
 target_compile_definitions(voice-input-addon PRIVATE
     VOICE_INPUT_VERSION="${PROJECT_VERSION}"


### PR DESCRIPTION
v0.4.0 将 PipeWire/PulseAudio 改为可选依赖并移除链接（PR #19），
但 capture 代码直接调用 pw_*/pa_* 符号（未走 dlsym），
导致 voice-input-addon.so 带 24 个未定义符号，fcitx5 dlopen 时失败， 整个语音输入插件无法加载，且无任何日志。

按可用性条件重新链接 ${PIPEWIRE_LIBRARIES} / ${PULSE_LIBRARIES}， 缺失的后端不编译也不链接，恢复 v0.3.x 行为。

PS:我在本地做了如下测试成功，                                                                                                                          
                                                                                                                                                                  
      sudo patchelf --add-needed libpipewire-0.3.so.0 /usr/lib/fcitx5/voice-input-addon.so                                                                                      
      sudo patchelf --add-needed libpulse-simple.so.0 /usr/lib/fcitx5/voice-input-addon.so