### PR TITLE
fix(capture): 录音库改为 dlsym 函数指针表，修复 Arch 构建下 addon 无法加载

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -45,11 +45,65 @@ runs:
 
     - name: Configure
       shell: bash
-      run: cmake -B build -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DCMAKE_INSTALL_PREFIX=/usr -DONNXRUNTIME_ROOT="${ONNXRUNTIME_ROOT}"
+      run: >-
+        cmake -B build -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DCMAKE_INSTALL_PREFIX=/usr
+        -DONNXRUNTIME_ROOT="${ONNXRUNTIME_ROOT}" -DCMAKE_MODULE_LINKER_FLAGS="-Wl,-z,now"
 
     - name: Compile
       shell: bash
       run: cmake --build build -j"$(nproc)"
+
+    # The capture libraries are intentionally runtime-loaded. Build success alone
+    # does not catch a direct pw_*/pa_* reference: with DF_1_NOW it only fails
+    # when fcitx dlopen()s the addon.
+    - name: Verify hardened addon loading
+      shell: bash
+      run: |
+        set -euo pipefail
+        export LC_ALL=C
+        addon="${PWD}/build/voice-input-addon.so"
+
+        if nm -D --undefined-only "${addon}" | awk '{print $NF}' | grep -qE '^(pw_|pa_)'; then
+          echo "::error::addon has unresolved PipeWire/PulseAudio symbols"
+          nm -D --undefined-only "${addon}" | awk '$NF ~ /^(pw_|pa_)/ {print}'
+          exit 1
+        fi
+
+        if readelf -dW "${addon}" | grep -qE 'Shared library: \[lib(pipewire|pulse)'; then
+          echo "::error::addon unexpectedly has a capture-library DT_NEEDED entry"
+          readelf -dW "${addon}" | grep -E 'Shared library: \[lib(pipewire|pulse)' || true
+          exit 1
+        fi
+
+        if ! readelf -dW "${addon}" | grep -qE 'BIND_NOW|FLAGS_1.*NOW'; then
+          echo "::error::addon was not linked with DF_1_NOW"
+          exit 1
+        fi
+
+        cat >/tmp/voice-input-dlopen-smoke.c <<'EOF'
+        #include <dlfcn.h>
+        #include <stdio.h>
+
+        int main(int argc, char **argv) {
+            if (argc != 2) {
+                return 2;
+            }
+            void *handle = dlopen(argv[1], RTLD_LAZY | RTLD_LOCAL);
+            if (!handle) {
+                fprintf(stderr, "dlopen failed: %s\n", dlerror());
+                return 1;
+            }
+            if (dlclose(handle) != 0) {
+                fprintf(stderr, "dlclose failed: %s\n", dlerror());
+                return 1;
+            }
+            return 0;
+        }
+        EOF
+        cc -Wall -Wextra -Werror /tmp/voice-input-dlopen-smoke.c -ldl \
+          -o /tmp/voice-input-dlopen-smoke
+        LD_LIBRARY_PATH="${ONNXRUNTIME_ROOT}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+          /tmp/voice-input-dlopen-smoke "${addon}"
 
     - name: Package DEB
       id: deb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ po/
 - **禁止安装**: 除非用户明确要求 `cmake --install`，否则只构建不安装。勿动 `/usr`、`~/.local` 等路径。
 - **PipeWire 回调**: `on_process` 内 ≤100μs，只写 ring buffer，禁止阻塞/VAD/分配
 - **音频捕获后端**: 可选编译（CMake 宏 `HAVE_PULSEAUDIO`/`HAVE_PIPEWIRE`），优先 PulseAudio（兼容 PulseAudio 和 pipewire-pulse），失败后 fallback 到 PipeWire 直连；仅编译进来的后端可用
-- **录音库运行期加载（dlopen）**: libpulse-simple/libpipewire **不链接**（无 DT_NEEDED），由各 capture 的 `LoadLib()` 在 Start 时 dlopen（RTLD_NOW|RTLD_GLOBAL，候选 soname 列表 + 关键符号 dlsym 校验）。fcitx5 以 RTLD_LAZY 加载 addon（`Library=` 无 `export:` 前缀），未定义符号延迟到首次调用解析——首次调用必在 LoadLib 成功后，故安全。库缺失/soname 变更时后端优雅降级，addon 本体不受影响
+- **录音库运行期加载（dlopen + dlsym 函数指针表）**: libpulse-simple/libpipewire **不链接**（无 DT_NEEDED、无未定义符号），各 capture 的 `LoadLib()` 在 Start 时 dlopen（RTLD_NOW|RTLD_GLOBAL，候选 soname 列表）并逐个 dlsym 填充函数指针表，所有 `pa_*`/`pw_*` 调用经函数指针间接调用。库缺失/soname 变更/符号不完整时后端优雅降级，addon 本体不受影响。兼容 Arch 构建的 `-z,now`（DF_1_NOW 强制立即绑定也无不解析符号，见 PR #20）
 - **PipeWire**: on_process→ringbuffer(float32)→DrainLoop thread→int16 AudioFrame→FrameQueue
 - **Ring buffer**: `Clear()` 被故意省略（与 PipeWire 回调 data race），清空用 `Read()` drain 模式
 - **音频格式统一**: 16kHz mono, int16, 512 samples/window (32ms)

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Uninstall a source installation recorded by CMake's install manifest.
+# Packaged installations (AUR/DEB/RPM) must be removed with their package manager.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/uninstall.sh [--dry-run] [--yes]
+
+Remove files installed by `cmake --install` using BUILD_DIR/install_manifest.txt.
+
+Environment:
+  BUILD_DIR  CMake build directory (default: <repository>/build)
+  PREFIX     Expected install prefix (default: prefix recorded in CMakeCache.txt)
+
+Options:
+  -n, --dry-run  List files that would be removed without changing anything.
+  -y, --yes      Do not ask for confirmation when run interactively.
+  -h, --help     Show this help message.
+
+This script preserves user configuration under ~/.config/fcitx5/.
+For AUR, DEB, or RPM installs, use the distribution package manager instead.
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+build_dir="${BUILD_DIR:-${repo_dir}/build}"
+if [[ "${build_dir}" != /* ]]; then
+    build_dir="${repo_dir}/${build_dir}"
+fi
+
+manifest="${build_dir}/install_manifest.txt"
+cache="${build_dir}/CMakeCache.txt"
+prefix="${PREFIX:-}"
+dry_run=false
+assume_yes=false
+
+while (($#)); do
+    case "$1" in
+        -n|--dry-run)
+            dry_run=true
+            ;;
+        -y|--yes)
+            assume_yes=true
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            fail "Unknown option: $1"
+            ;;
+    esac
+    shift
+done
+
+[[ -r "${manifest}" ]] || fail "No install manifest at ${manifest}. Reinstall from this build directory first, or use your package manager."
+[[ -r "${cache}" ]] || fail "No CMake cache at ${cache}; refusing to trust the manifest without it."
+grep -qx 'CMAKE_PROJECT_NAME:STATIC=fcitx5-voice-input' "${cache}" || \
+    fail "${build_dir} is not a fcitx5-voice-input build directory."
+
+if [[ -z "${prefix}" ]]; then
+    prefix="$(awk -F= '$1 == "CMAKE_INSTALL_PREFIX:PATH" { print $2; exit }' "${cache}")"
+fi
+[[ -n "${prefix}" && "${prefix}" == /* ]] || fail "PREFIX must be an absolute path."
+prefix="${prefix%/}"
+[[ -n "${prefix}" ]] || fail "Refusing to uninstall from filesystem root."
+
+mapfile -t installed_files < "${manifest}"
+((${#installed_files[@]} > 0)) || fail "Install manifest is empty: ${manifest}"
+
+for path in "${installed_files[@]}"; do
+    [[ -n "${path}" ]] || continue
+    [[ "${path}" == "${prefix}/"* ]] ||
+        fail "Manifest path is outside PREFIX (${prefix}): ${path}. Set PREFIX to the prefix used for installation."
+done
+
+package_owner() {
+    local path="$1" owner
+
+    if command -v pacman >/dev/null 2>&1 && owner="$(pacman -Qo -- "${path}" 2>/dev/null)"; then
+        printf '%s\n' "${owner}"
+        return 0
+    fi
+    if command -v dpkg-query >/dev/null 2>&1 && owner="$(dpkg-query -S -- "${path}" 2>/dev/null)"; then
+        printf '%s\n' "${owner}"
+        return 0
+    fi
+    if command -v rpm >/dev/null 2>&1 && owner="$(rpm -qf -- "${path}" 2>/dev/null)"; then
+        printf '%s\n' "${owner}"
+        return 0
+    fi
+    return 1
+}
+
+for path in "${installed_files[@]}"; do
+    [[ -e "${path}" || -L "${path}" ]] || continue
+    if owner="$(package_owner "${path}")"; then
+        fail "${path} is package-managed (${owner}). Use your distribution package manager instead."
+    fi
+done
+
+echo "==> Files recorded for removal:"
+printf '    %s\n' "${installed_files[@]}"
+
+if "${dry_run}"; then
+    echo "==> Dry run only; no files were removed."
+    exit 0
+fi
+
+if [[ -t 0 && "${assume_yes}" != true ]]; then
+    read -r -p "Remove these files? [y/N] " reply
+    case "${reply}" in
+        y|Y|yes|YES)
+            ;;
+        *)
+            echo "==> Uninstall cancelled."
+            exit 0
+            ;;
+    esac
+fi
+
+if [[ ${EUID} -eq 0 || -w "${prefix}" ]]; then
+    privilege=()
+else
+    command -v sudo >/dev/null 2>&1 || fail "Write access to ${prefix} requires sudo, but sudo was not found."
+    privilege=(sudo)
+fi
+
+"${privilege[@]}" rm -f -- "${installed_files[@]}"
+
+# Only these directories are project-specific; remove them if they became empty.
+for path in "${installed_files[@]}"; do
+    if [[ "${path}" == */fcitx5/voice-input/models/silero_vad.onnx ]]; then
+        "${privilege[@]}" rmdir -- "$(dirname -- "${path}")" 2>/dev/null || true
+        "${privilege[@]}" rmdir -- "$(dirname -- "$(dirname -- "${path}")")" 2>/dev/null || true
+        break
+    fi
+done
+
+echo "==> Uninstalled. User configuration under ~/.config/fcitx5/ was kept."
+echo "==> Restart fcitx5 (or log out and back in) to unload the removed addon."

--- a/src/addon/capture/pipewire_capture.cpp
+++ b/src/addon/capture/pipewire_capture.cpp
@@ -28,26 +28,51 @@ PipeWireCapture::~PipeWireCapture() {
     Stop();
 }
 
-// dlopen 加载 libpipewire 并校验关键符号。
-// 返回 true 后所有 pw_* 调用均安全；失败则本后端不可用（Start 返回 false，
-// 由 pipeline 回退到其他后端），不影响 addon 本体加载。
+// dlopen 加载 libpipewire 并通过 dlsym 填充函数指针表。
+// 返回 true 后所有 pw_* 调用均安全（经 pw_ 间接调用，无未定义符号）；
+// 失败则本后端不可用（Start 返回 false，由 pipeline 回退到其他后端），
+// 不影响 addon 本体加载。
 bool PipeWireCapture::LoadLib() {
-    if (pwLib_) return true;
+    if (pw_.handle) return true;
 
     for (const char* soname : kPwLibCandidates) {
         void* handle = dlopen(soname, RTLD_NOW | RTLD_GLOBAL);
         if (!handle) continue;
 
+        PwLib lib{};
+        lib.handle = handle;
+#define PW_LOAD(sym) \
+        lib.sym = reinterpret_cast<decltype(lib.sym)>(dlsym(handle, #sym))
+        PW_LOAD(pw_init);
+        PW_LOAD(pw_thread_loop_new);
+        PW_LOAD(pw_thread_loop_get_loop);
+        PW_LOAD(pw_context_new);
+        PW_LOAD(pw_context_connect);
+        PW_LOAD(pw_context_destroy);
+        PW_LOAD(pw_properties_new);
+        PW_LOAD(pw_stream_new);
+        PW_LOAD(pw_stream_add_listener);
+        PW_LOAD(pw_stream_connect);
+        PW_LOAD(pw_stream_dequeue_buffer);
+        PW_LOAD(pw_stream_queue_buffer);
+        PW_LOAD(pw_stream_destroy);
+        PW_LOAD(pw_core_disconnect);
+        PW_LOAD(pw_thread_loop_destroy);
+        PW_LOAD(pw_thread_loop_start);
+        PW_LOAD(pw_thread_loop_stop);
+        PW_LOAD(pw_stream_state_as_string);
+#undef PW_LOAD
+
         // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
-        // 必须确认入口符号真实存在，否则后续调用会 undefined symbol 崩溃
-        if (!dlsym(handle, "pw_init")) {
+        // 任一入口缺失即拒绝，避免后续调用空指针崩溃
+        if (!lib.valid()) {
             FCITX_WARN() << "[voice-input:pw] " << soname
-                         << " loaded but pw_init missing: " << dlerror();
+                         << " loaded but symbols incomplete: " << dlerror();
             dlclose(handle);
             continue;
         }
 
-        pwLib_ = handle;
+        pw_ = lib;
         FCITX_INFO() << "[voice-input:pw] Runtime-loaded " << soname;
         return true;
     }
@@ -58,9 +83,9 @@ bool PipeWireCapture::LoadLib() {
 }
 
 void PipeWireCapture::UnloadLib() {
-    if (pwLib_) {
-        dlclose(pwLib_);
-        pwLib_ = nullptr;
+    if (pw_.handle) {
+        dlclose(pw_.handle);
+        pw_ = PwLib{};
     }
 }
 
@@ -69,16 +94,16 @@ bool PipeWireCapture::Start() {
 
     if (!LoadLib()) return false;
 
-    pw_init(nullptr, nullptr);
+    pw_.pw_init(nullptr, nullptr);
 
-    loop_ = pw_thread_loop_new("voice-input-capture", nullptr);
+    loop_ = pw_.pw_thread_loop_new("voice-input-capture", nullptr);
     if (!loop_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_thread_loop";
         UnloadLib();
         return false;
     }
 
-    context_ = pw_context_new(pw_thread_loop_get_loop(loop_), nullptr, 0);
+    context_ = pw_.pw_context_new(pw_.pw_thread_loop_get_loop(loop_), nullptr, 0);
     if (!context_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_context";
         Cleanup(false);
@@ -86,7 +111,7 @@ bool PipeWireCapture::Start() {
         return false;
     }
 
-    core_ = pw_context_connect(context_, nullptr, 0);
+    core_ = pw_.pw_context_connect(context_, nullptr, 0);
     if (!core_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to connect pw_context";
         Cleanup(false);
@@ -95,7 +120,7 @@ bool PipeWireCapture::Start() {
     }
 
     struct pw_properties* props =
-        pw_properties_new(
+        pw_.pw_properties_new(
             PW_KEY_MEDIA_TYPE, "Audio",
             PW_KEY_MEDIA_CATEGORY, "Capture",
             PW_KEY_MEDIA_ROLE, "Communication",
@@ -103,7 +128,7 @@ bool PipeWireCapture::Start() {
             PW_KEY_NODE_DESCRIPTION, "Voice Input Audio Capture",
             nullptr);
 
-    stream_ = pw_stream_new(core_, "voice-input-capture", props);
+    stream_ = pw_.pw_stream_new(core_, "voice-input-capture", props);
     if (!stream_) {
         FCITX_ERROR() << "[voice-input:pw] Failed to create pw_stream";
         Cleanup(false);
@@ -119,7 +144,7 @@ bool PipeWireCapture::Start() {
         return events;
     }();
 
-    pw_stream_add_listener(stream_, &streamListener_, &stream_events, this);
+    pw_.pw_stream_add_listener(stream_, &streamListener_, &stream_events, this);
 
     uint8_t buffer[1024];
     spa_audio_info_raw audio_info = {};
@@ -131,7 +156,7 @@ bool PipeWireCapture::Start() {
     const spa_pod* params[1];
     params[0] = spa_format_audio_raw_build(&podBuilder, SPA_PARAM_EnumFormat, &audio_info);
 
-    int connectResult = pw_stream_connect(stream_,
+    int connectResult = pw_.pw_stream_connect(stream_,
                                           PW_DIRECTION_INPUT,
                                           PW_ID_ANY,
                                           static_cast<pw_stream_flags>(
@@ -146,7 +171,7 @@ bool PipeWireCapture::Start() {
         return false;
     }
 
-    if (pw_thread_loop_start(loop_) < 0) {
+    if (pw_.pw_thread_loop_start(loop_) < 0) {
         FCITX_ERROR() << "[voice-input:pw] Failed to start pw_thread_loop";
         Cleanup(false);
         UnloadLib();
@@ -180,22 +205,22 @@ void PipeWireCapture::Stop() {
 
 void PipeWireCapture::Cleanup(bool stopLoop) {
     if (stopLoop && loop_) {
-        pw_thread_loop_stop(loop_);
+        pw_.pw_thread_loop_stop(loop_);
     }
     if (stream_) {
-        pw_stream_destroy(stream_);
+        pw_.pw_stream_destroy(stream_);
         stream_ = nullptr;
     }
     if (core_) {
-        pw_core_disconnect(core_);
+        pw_.pw_core_disconnect(core_);
         core_ = nullptr;
     }
     if (context_) {
-        pw_context_destroy(context_);
+        pw_.pw_context_destroy(context_);
         context_ = nullptr;
     }
     if (loop_) {
-        pw_thread_loop_destroy(loop_);
+        pw_.pw_thread_loop_destroy(loop_);
         loop_ = nullptr;
     }
 }
@@ -205,16 +230,17 @@ void PipeWireCapture::OnProcess(void* userdata) {
     self->OnProcessImpl();
 }
 
-void PipeWireCapture::OnStateChanged(void*, pw_stream_state oldState,
+void PipeWireCapture::OnStateChanged(void* userdata, pw_stream_state oldState,
                                      pw_stream_state state, const char* error) {
+    auto* self = static_cast<PipeWireCapture*>(userdata);
     FCITX_DEBUG() << "[voice-input:pw] Stream state: "
-                 << pw_stream_state_as_string(oldState) << " -> "
-                 << pw_stream_state_as_string(state)
+                 << self->pw_.pw_stream_state_as_string(oldState) << " -> "
+                 << self->pw_.pw_stream_state_as_string(state)
                  << (error ? " error=" : "") << (error ? error : "");
 }
 
 void PipeWireCapture::OnProcessImpl() {
-    pw_buffer* buf = pw_stream_dequeue_buffer(stream_);
+    pw_buffer* buf = pw_.pw_stream_dequeue_buffer(stream_);
     if (!buf) {
         FCITX_DEBUG() << "[voice-input:pw] dequeue_buffer returned null";
         return;
@@ -222,20 +248,20 @@ void PipeWireCapture::OnProcessImpl() {
 
     struct spa_buffer* spa_buf = buf->buffer;
     if (spa_buf->n_datas == 0) {
-        pw_stream_queue_buffer(stream_, buf);
+        pw_.pw_stream_queue_buffer(stream_, buf);
         return;
     }
 
     void* src = spa_buf->datas[0].data;
     auto* chunk = spa_buf->datas[0].chunk;
     if (!chunk) {
-        pw_stream_queue_buffer(stream_, buf);
+        pw_.pw_stream_queue_buffer(stream_, buf);
         return;
     }
     uint32_t size = chunk->size;
 
     if (!src || size == 0) {
-        pw_stream_queue_buffer(stream_, buf);
+        pw_.pw_stream_queue_buffer(stream_, buf);
         return;
     }
 
@@ -247,7 +273,7 @@ void PipeWireCapture::OnProcessImpl() {
         rawCallback_(pcm, frames);
     }
 
-    pw_stream_queue_buffer(stream_, buf);
+    pw_.pw_stream_queue_buffer(stream_, buf);
 }
 
 void PipeWireCapture::DrainLoop() {

--- a/src/addon/capture/pipewire_capture.cpp
+++ b/src/addon/capture/pipewire_capture.cpp
@@ -41,8 +41,14 @@ bool PipeWireCapture::LoadLib() {
 
         PwLib lib{};
         lib.handle = handle;
-#define PW_LOAD(sym) \
-        lib.sym = reinterpret_cast<decltype(lib.sym)>(dlsym(handle, #sym))
+        const char* missingSymbol = nullptr;
+#define PW_LOAD(sym)                                                                  \
+        do {                                                                          \
+            lib.sym = reinterpret_cast<decltype(lib.sym)>(dlsym(handle, #sym));     \
+            if (!lib.sym && !missingSymbol) {                                        \
+                missingSymbol = #sym;                                                \
+            }                                                                         \
+        } while (false)
         PW_LOAD(pw_init);
         PW_LOAD(pw_thread_loop_new);
         PW_LOAD(pw_thread_loop_get_loop);
@@ -64,10 +70,11 @@ bool PipeWireCapture::LoadLib() {
 #undef PW_LOAD
 
         // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
-        // 任一入口缺失即拒绝，避免后续调用空指针崩溃
+        // 任一入口缺失即拒绝，避免后续调用空指针崩溃。
         if (!lib.valid()) {
             FCITX_WARN() << "[voice-input:pw] " << soname
-                         << " loaded but symbols incomplete: " << dlerror();
+                         << " loaded but required symbol missing: "
+                         << (missingSymbol ? missingSymbol : "unknown");
             dlclose(handle);
             continue;
         }

--- a/src/addon/capture/pipewire_capture.h
+++ b/src/addon/capture/pipewire_capture.h
@@ -39,10 +39,42 @@ private:
     void Cleanup(bool stopLoop);
     void DrainLoop();
 
-    // 运行期 dlopen 句柄（RTLD_GLOBAL 加载 libpipewire，避免链接期
-    // DT_NEEDED 硬依赖——库升级/soname 变更时 addon 仍可加载）
-    void* pwLib_ = nullptr;
+    // 运行期 dlopen + dlsym 函数指针表。所有 pw_* 调用经由此表间接调用，
+    // addon 无任何 pw_* 未定义符号——即使 Arch 构建的 DF_1_NOW (-z,now)
+    // 强制立即绑定，addon 也能正常加载（见 PR #20）。
+    struct PwLib {
+        void* handle = nullptr;
+        void (*pw_init)(int*, char***) = nullptr;
+        pw_thread_loop* (*pw_thread_loop_new)(const char*, const struct spa_dict*) = nullptr;
+        pw_loop* (*pw_thread_loop_get_loop)(pw_thread_loop*) = nullptr;
+        pw_context* (*pw_context_new)(pw_loop*, pw_properties*, size_t) = nullptr;
+        pw_core* (*pw_context_connect)(pw_context*, pw_properties*, size_t) = nullptr;
+        void (*pw_context_destroy)(pw_context*) = nullptr;
+        pw_properties* (*pw_properties_new)(const char*, ...) = nullptr;
+        pw_stream* (*pw_stream_new)(pw_core*, const char*, pw_properties*) = nullptr;
+        int (*pw_stream_add_listener)(pw_stream*, struct spa_hook*,
+                                      const pw_stream_events*, void*) = nullptr;
+        int (*pw_stream_connect)(pw_stream*, pw_direction, uint32_t, pw_stream_flags,
+                                 const spa_pod**, uint32_t) = nullptr;
+        pw_buffer* (*pw_stream_dequeue_buffer)(pw_stream*) = nullptr;
+        int (*pw_stream_queue_buffer)(pw_stream*, pw_buffer*) = nullptr;
+        void (*pw_stream_destroy)(pw_stream*) = nullptr;
+        void (*pw_core_disconnect)(pw_core*) = nullptr;
+        void (*pw_thread_loop_destroy)(pw_thread_loop*) = nullptr;
+        int (*pw_thread_loop_start)(pw_thread_loop*) = nullptr;
+        void (*pw_thread_loop_stop)(pw_thread_loop*) = nullptr;
+        const char* (*pw_stream_state_as_string)(pw_stream_state) = nullptr;
+        bool valid() const {
+            return handle && pw_init && pw_thread_loop_new && pw_thread_loop_get_loop &&
+                   pw_context_new && pw_context_connect && pw_context_destroy &&
+                   pw_properties_new && pw_stream_new && pw_stream_add_listener &&
+                   pw_stream_connect && pw_stream_dequeue_buffer && pw_stream_queue_buffer &&
+                   pw_stream_destroy && pw_core_disconnect && pw_thread_loop_destroy &&
+                   pw_thread_loop_start && pw_thread_loop_stop && pw_stream_state_as_string;
+        }
+    };
 
+    PwLib pw_;
     pw_thread_loop* loop_ = nullptr;
     pw_context* context_ = nullptr;
     pw_core* core_ = nullptr;

--- a/src/addon/capture/pipewire_capture.h
+++ b/src/addon/capture/pipewire_capture.h
@@ -44,26 +44,25 @@ private:
     // 强制立即绑定，addon 也能正常加载（见 PR #20）。
     struct PwLib {
         void* handle = nullptr;
-        void (*pw_init)(int*, char***) = nullptr;
-        pw_thread_loop* (*pw_thread_loop_new)(const char*, const struct spa_dict*) = nullptr;
-        pw_loop* (*pw_thread_loop_get_loop)(pw_thread_loop*) = nullptr;
-        pw_context* (*pw_context_new)(pw_loop*, pw_properties*, size_t) = nullptr;
-        pw_core* (*pw_context_connect)(pw_context*, pw_properties*, size_t) = nullptr;
-        void (*pw_context_destroy)(pw_context*) = nullptr;
-        pw_properties* (*pw_properties_new)(const char*, ...) = nullptr;
-        pw_stream* (*pw_stream_new)(pw_core*, const char*, pw_properties*) = nullptr;
-        int (*pw_stream_add_listener)(pw_stream*, struct spa_hook*,
-                                      const pw_stream_events*, void*) = nullptr;
-        int (*pw_stream_connect)(pw_stream*, pw_direction, uint32_t, pw_stream_flags,
-                                 const spa_pod**, uint32_t) = nullptr;
-        pw_buffer* (*pw_stream_dequeue_buffer)(pw_stream*) = nullptr;
-        int (*pw_stream_queue_buffer)(pw_stream*, pw_buffer*) = nullptr;
-        void (*pw_stream_destroy)(pw_stream*) = nullptr;
-        void (*pw_core_disconnect)(pw_core*) = nullptr;
-        void (*pw_thread_loop_destroy)(pw_thread_loop*) = nullptr;
-        int (*pw_thread_loop_start)(pw_thread_loop*) = nullptr;
-        void (*pw_thread_loop_stop)(pw_thread_loop*) = nullptr;
-        const char* (*pw_stream_state_as_string)(pw_stream_state) = nullptr;
+        // 从编译期头文件推导精确 ABI 签名，避免手写函数指针与上游 API 漂移。
+        decltype(&::pw_init) pw_init = nullptr;
+        decltype(&::pw_thread_loop_new) pw_thread_loop_new = nullptr;
+        decltype(&::pw_thread_loop_get_loop) pw_thread_loop_get_loop = nullptr;
+        decltype(&::pw_context_new) pw_context_new = nullptr;
+        decltype(&::pw_context_connect) pw_context_connect = nullptr;
+        decltype(&::pw_context_destroy) pw_context_destroy = nullptr;
+        decltype(&::pw_properties_new) pw_properties_new = nullptr;
+        decltype(&::pw_stream_new) pw_stream_new = nullptr;
+        decltype(&::pw_stream_add_listener) pw_stream_add_listener = nullptr;
+        decltype(&::pw_stream_connect) pw_stream_connect = nullptr;
+        decltype(&::pw_stream_dequeue_buffer) pw_stream_dequeue_buffer = nullptr;
+        decltype(&::pw_stream_queue_buffer) pw_stream_queue_buffer = nullptr;
+        decltype(&::pw_stream_destroy) pw_stream_destroy = nullptr;
+        decltype(&::pw_core_disconnect) pw_core_disconnect = nullptr;
+        decltype(&::pw_thread_loop_destroy) pw_thread_loop_destroy = nullptr;
+        decltype(&::pw_thread_loop_start) pw_thread_loop_start = nullptr;
+        decltype(&::pw_thread_loop_stop) pw_thread_loop_stop = nullptr;
+        decltype(&::pw_stream_state_as_string) pw_stream_state_as_string = nullptr;
         bool valid() const {
             return handle && pw_init && pw_thread_loop_new && pw_thread_loop_get_loop &&
                    pw_context_new && pw_context_connect && pw_context_destroy &&

--- a/src/addon/capture/pulse_audio_capture.cpp
+++ b/src/addon/capture/pulse_audio_capture.cpp
@@ -90,20 +90,26 @@ bool PulseAudioCapture::LoadLib() {
 
         PulseLib lib{};
         lib.handle = handle;
-        lib.pa_simple_new =
-            reinterpret_cast<decltype(lib.pa_simple_new)>(dlsym(handle, "pa_simple_new"));
-        lib.pa_simple_free =
-            reinterpret_cast<decltype(lib.pa_simple_free)>(dlsym(handle, "pa_simple_free"));
-        lib.pa_simple_read =
-            reinterpret_cast<decltype(lib.pa_simple_read)>(dlsym(handle, "pa_simple_read"));
-        lib.pa_strerror =
-            reinterpret_cast<decltype(lib.pa_strerror)>(dlsym(handle, "pa_strerror"));
+        const char* missingSymbol = nullptr;
+#define PULSE_LOAD(sym)                                                               \
+        do {                                                                          \
+            lib.sym = reinterpret_cast<decltype(lib.sym)>(dlsym(handle, #sym));     \
+            if (!lib.sym && !missingSymbol) {                                        \
+                missingSymbol = #sym;                                                \
+            }                                                                         \
+        } while (false)
+        PULSE_LOAD(pa_simple_new);
+        PULSE_LOAD(pa_simple_free);
+        PULSE_LOAD(pa_simple_read);
+        PULSE_LOAD(pa_strerror);
+#undef PULSE_LOAD
 
         // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
-        // 任一入口缺失即拒绝，避免后续调用空指针崩溃
+        // 任一入口缺失即拒绝，避免后续调用空指针崩溃。
         if (!lib.valid()) {
             FCITX_WARN() << "[voice-input:pulse] " << soname
-                         << " loaded but symbols incomplete: " << dlerror();
+                         << " loaded but required symbol missing: "
+                         << (missingSymbol ? missingSymbol : "unknown");
             dlclose(handle);
             continue;
         }

--- a/src/addon/capture/pulse_audio_capture.cpp
+++ b/src/addon/capture/pulse_audio_capture.cpp
@@ -77,26 +77,38 @@ PulseAudioCapture::PulseAudioCapture() = default;
 
 PulseAudioCapture::~PulseAudioCapture() { Stop(); }
 
-// dlopen 加载 libpulse-simple 并校验关键符号。
-// 返回 true 后所有 pa_* 调用均安全；失败则本后端不可用（Start 返回 false，
-// 由 pipeline 回退到其他后端），不影响 addon 本体加载。
+// dlopen 加载 libpulse-simple 并通过 dlsym 填充函数指针表。
+// 返回 true 后所有 pa_* 调用均安全（经 pulse_ 间接调用，无未定义符号）；
+// 失败则本后端不可用（Start 返回 false，由 pipeline 回退到其他后端），
+// 不影响 addon 本体加载。
 bool PulseAudioCapture::LoadLib() {
-    if (pulseLib_) return true;
+    if (pulse_.handle) return true;
 
     for (const char* soname : kPulseLibCandidates) {
         void* handle = dlopen(soname, RTLD_NOW | RTLD_GLOBAL);
         if (!handle) continue;
 
+        PulseLib lib{};
+        lib.handle = handle;
+        lib.pa_simple_new =
+            reinterpret_cast<decltype(lib.pa_simple_new)>(dlsym(handle, "pa_simple_new"));
+        lib.pa_simple_free =
+            reinterpret_cast<decltype(lib.pa_simple_free)>(dlsym(handle, "pa_simple_free"));
+        lib.pa_simple_read =
+            reinterpret_cast<decltype(lib.pa_simple_read)>(dlsym(handle, "pa_simple_read"));
+        lib.pa_strerror =
+            reinterpret_cast<decltype(lib.pa_strerror)>(dlsym(handle, "pa_strerror"));
+
         // 符号完整性校验：同名 soname 可能被错误实现/损坏库占用，
-        // 必须确认入口符号真实存在，否则后续调用会 undefined symbol 崩溃
-        if (!dlsym(handle, "pa_simple_new")) {
+        // 任一入口缺失即拒绝，避免后续调用空指针崩溃
+        if (!lib.valid()) {
             FCITX_WARN() << "[voice-input:pulse] " << soname
-                         << " loaded but pa_simple_new missing: " << dlerror();
+                         << " loaded but symbols incomplete: " << dlerror();
             dlclose(handle);
             continue;
         }
 
-        pulseLib_ = handle;
+        pulse_ = lib;
         FCITX_INFO() << "[voice-input:pulse] Runtime-loaded " << soname;
         return true;
     }
@@ -107,9 +119,9 @@ bool PulseAudioCapture::LoadLib() {
 }
 
 void PulseAudioCapture::UnloadLib() {
-    if (pulseLib_) {
-        dlclose(pulseLib_);
-        pulseLib_ = nullptr;
+    if (pulse_.handle) {
+        dlclose(pulse_.handle);
+        pulse_ = PulseLib{};
     }
 }
 
@@ -127,19 +139,19 @@ bool PulseAudioCapture::Start() {
     const char* device = sourceName.empty() ? nullptr : sourceName.c_str();
 
     int error = 0;
-    stream_ = pa_simple_new(nullptr,
-                            "fcitx5-voice-input",
-                            PA_STREAM_RECORD,
-                            device,
-                            "voice input",
-                            &sampleSpec,
-                            nullptr,
-                            nullptr,
-                            &error);
+    stream_ = pulse_.pa_simple_new(nullptr,
+                                   "fcitx5-voice-input",
+                                   PA_STREAM_RECORD,
+                                   device,
+                                   "voice input",
+                                   &sampleSpec,
+                                   nullptr,
+                                   nullptr,
+                                   &error);
     if (!stream_) {
         FCITX_ERROR() << "[voice-input:pulse] Failed to open source: "
                       << (device ? device : "(default)")
-                      << " — " << pa_strerror(error);
+                      << " — " << pulse_.pa_strerror(error);
         UnloadLib();
         return false;
     }
@@ -167,7 +179,7 @@ void PulseAudioCapture::Stop() {
     }
 
     if (stream_) {
-        pa_simple_free(stream_);
+        pulse_.pa_simple_free(stream_);
         stream_ = nullptr;
     }
     UnloadLib();
@@ -179,11 +191,11 @@ void PulseAudioCapture::CaptureLoop() {
 
     while (running_) {
         int error = 0;
-        if (pa_simple_read(stream_, buffer.data(),
-                           buffer.size() * sizeof(int16_t), &error) < 0) {
+        if (pulse_.pa_simple_read(stream_, buffer.data(),
+                                  buffer.size() * sizeof(int16_t), &error) < 0) {
             if (running_) {
                 FCITX_ERROR() << "[voice-input:pulse] Read failed: "
-                              << pa_strerror(error);
+                              << pulse_.pa_strerror(error);
             }
             running_ = false;
             break;

--- a/src/addon/capture/pulse_audio_capture.h
+++ b/src/addon/capture/pulse_audio_capture.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <thread>
 
+#include <pulse/error.h>
 #include <pulse/simple.h>
 
 #include "capture/audio_capture.h"
@@ -31,12 +32,11 @@ private:
     // 强制立即绑定，addon 也能正常加载（见 PR #20）。
     struct PulseLib {
         void* handle = nullptr;
-        pa_simple* (*pa_simple_new)(const char*, const char*, pa_stream_direction,
-                                    const char*, const char*, const pa_sample_spec*,
-                                    const pa_channel_map*, const pa_buffer_attr*, int*) = nullptr;
-        void (*pa_simple_free)(pa_simple*) = nullptr;
-        int (*pa_simple_read)(pa_simple*, void*, size_t, int*) = nullptr;
-        const char* (*pa_strerror)(int) = nullptr;
+        // 从编译期头文件推导精确 ABI 签名，避免手写函数指针与上游 API 漂移。
+        decltype(&::pa_simple_new) pa_simple_new = nullptr;
+        decltype(&::pa_simple_free) pa_simple_free = nullptr;
+        decltype(&::pa_simple_read) pa_simple_read = nullptr;
+        decltype(&::pa_strerror) pa_strerror = nullptr;
         bool valid() const { return handle && pa_simple_new && pa_simple_free && pa_simple_read && pa_strerror; }
     };
 

--- a/src/addon/capture/pulse_audio_capture.h
+++ b/src/addon/capture/pulse_audio_capture.h
@@ -26,9 +26,21 @@ public:
     const char* Name() const override { return "pulseaudio"; }
 
 private:
-    // 运行期 dlopen 句柄（RTLD_GLOBAL 加载 libpulse-simple，避免链接期
-    // DT_NEEDED 硬依赖——库升级/soname 变更时 addon 仍可加载）
-    void* pulseLib_ = nullptr;
+    // 运行期 dlopen + dlsym 函数指针表。所有 pa_* 调用经由此表间接调用，
+    // addon 无任何 pa_* 未定义符号——即使 Arch 构建的 DF_1_NOW (-z,now)
+    // 强制立即绑定，addon 也能正常加载（见 PR #20）。
+    struct PulseLib {
+        void* handle = nullptr;
+        pa_simple* (*pa_simple_new)(const char*, const char*, pa_stream_direction,
+                                    const char*, const char*, const pa_sample_spec*,
+                                    const pa_channel_map*, const pa_buffer_attr*, int*) = nullptr;
+        void (*pa_simple_free)(pa_simple*) = nullptr;
+        int (*pa_simple_read)(pa_simple*, void*, size_t, int*) = nullptr;
+        const char* (*pa_strerror)(int) = nullptr;
+        bool valid() const { return handle && pa_simple_new && pa_simple_free && pa_simple_read && pa_strerror; }
+    };
+
+    PulseLib pulse_;
     bool LoadLib();
     void UnloadLib();
     void CaptureLoop();


### PR DESCRIPTION
## 背景

修复 PR #20 报告的问题：v0.4.0 在 Arch/AUR 构建下 `voice-input-addon.so` 带未定义符号，fcitx5 dlopen 失败，整个插件无法加载。

## 根因（非 v0.4.0 的 dlopen 思路本身错误，而是裸符号方案与构建标志不兼容）

- Arch `makepkg` 默认 LDFLAGS 含 **`-Wl,-z,now`**（`/etc/makepkg.conf` 确认）→ addon 带 `DF_1_NOW` 标志
- glibc：`dlopen(RTLD_LAZY)` 加载带 `DF_1_NOW` 的对象时**仍强制立即解析所有 PLT 符号**
- v0.4.0 的裸符号 dlopen 方案：addon 保留 22 个 `pw_*`/`pa_*` 未定义符号 → DF_1_NOW 下 dlopen 立即失败（`undefined symbol: pw_properties_new`）
- 本地 `cmake --build`（无 `-z,now`）→ 无 DF_1_NOW → RTLD_LAZY 延迟绑定 → 正常。这就是"本地没问题、Arch 构建有问题"的差异来源
- 复现实测：`-z,now` 链接的含未定义符号库 + `dlopen(RTLD_LAZY)` → 失败

## 修复

**dlsym 函数指针表**：所有 `pa_*`/`pw_*` 调用改为经 `LoadLib()` 中逐个 `dlsym` 填充的函数指针间接调用（pulse 4 个函数，pipewire 18 个函数，全量符号完整性校验）。

- addon **零录音库未定义符号** → DF_1_NOW 构建下同样正常加载
- **保留 v0.4.0 的目标**：无 DT_NEEDED 依赖，库升级/soname 变更不影响已安装 addon，后端优雅降级（与 PR #20 的回退方案不同，不回退到链接期硬依赖）

## 验证

| 场景 | 结果 |
|---|---|
| 零未定义符号（`nm -D`） | ✅ 0 个 `pw_*`/`pa_*` |
| `-z,now` 构建 + `RTLD_LAZY` 加载（复现 PR #20） | ✅ 成功 |
| 真实 Pulse 全链路 Start/Stop | ✅ |
| 真实 PipeWire 全链路 Start/Stop | ✅ |
| 假库占用同名 soname（符号校验拦截） | ✅ 优雅降级无崩溃 |