### PR TITLE
fix(packaging): require PulseAudio capture baseline

### DIFF
--- a/.github/actions/aur/build.sh
+++ b/.github/actions/aur/build.sh
@@ -25,12 +25,12 @@ runuser -u builder -- sh -c "cd '${PWD}/${WORK_DIR}' && makepkg -f --noconfirm"
 
 PKGFILE=$(ls "${WORK_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1 || true)
 if [ -n "${PKGFILE}" ]; then
-    PKGINFO=$(pacman -Qip "${PKGFILE}")
-    if ! grep -q 'libpulse' <<<"${PKGINFO}"; then
+    PKGINFO=$(bsdtar -xOf "${PKGFILE}" .PKGINFO)
+    if ! grep -Fxq 'depend = libpulse' <<<"${PKGINFO}"; then
         echo "::error::Arch package is missing required libpulse dependency"
         exit 1
     fi
-    if ! grep -q 'pipewire' <<<"${PKGINFO}"; then
+    if ! grep -Eq '^optdepend = pipewire:' <<<"${PKGINFO}"; then
         echo "::error::Arch package is missing PipeWire fallback optdependency"
         exit 1
     fi

--- a/.github/actions/aur/build.sh
+++ b/.github/actions/aur/build.sh
@@ -25,6 +25,15 @@ runuser -u builder -- sh -c "cd '${PWD}/${WORK_DIR}' && makepkg -f --noconfirm"
 
 PKGFILE=$(ls "${WORK_DIR}"/*.pkg.tar.zst 2>/dev/null | head -1 || true)
 if [ -n "${PKGFILE}" ]; then
+    PKGINFO=$(pacman -Qip "${PKGFILE}")
+    if ! grep -q 'libpulse' <<<"${PKGINFO}"; then
+        echo "::error::Arch package is missing required libpulse dependency"
+        exit 1
+    fi
+    if ! grep -q 'pipewire' <<<"${PKGINFO}"; then
+        echo "::error::Arch package is missing PipeWire fallback optdependency"
+        exit 1
+    fi
     cp "${PKGFILE}" "${OUT_DIR}/"
     echo "pkgfile=${PKGFILE}" >> "${GITHUB_OUTPUT}"
 else

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -87,6 +87,7 @@ runs:
         -DCPACK_DEBIAN_PACKAGE_DEPENDS="${CPACK_DEBIAN_PACKAGE_DEPENDS:-}"
         -DCPACK_DEBIAN_PACKAGE_RECOMMENDS="${CPACK_DEBIAN_PACKAGE_RECOMMENDS:-}"
         -DCPACK_DEBIAN_PACKAGE_SHLIBDEPS="${CPACK_DEBIAN_PACKAGE_SHLIBDEPS:-OFF}"
+        -DCPACK_RPM_PACKAGE_REQUIRES="${CPACK_RPM_PACKAGE_REQUIRES:-}"
 
     - name: Compile
       shell: bash
@@ -206,7 +207,18 @@ runs:
               exit 1
             fi
             ;;
-          RPM) rpm -qpi "${PACKAGE}" ;;
+          RPM)
+            rpm -qpi "${PACKAGE}"
+            if [ -z "${CPACK_RPM_PACKAGE_REQUIRES:-}" ]; then
+              echo "::error::RPM PulseAudio runtime dependency is not configured"
+              exit 1
+            fi
+            REQUIRES=$(rpm -qp --requires "${PACKAGE}")
+            if ! grep -Fxq -- "${CPACK_RPM_PACKAGE_REQUIRES}" <<<"${REQUIRES}"; then
+              echo "::error::RPM package is missing required ${CPACK_RPM_PACKAGE_REQUIRES} dependency"
+              exit 1
+            fi
+            ;;
         esac
         echo "::endgroup::"
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -193,7 +193,19 @@ runs:
 
         echo "::group::Package info"
         case "${CPACK_GEN}" in
-          DEB) dpkg-deb --info "${PACKAGE}" ;;
+          DEB)
+            dpkg-deb --info "${PACKAGE}"
+            DEPENDS=$(dpkg-deb -f "${PACKAGE}" Depends)
+            RECOMMENDS=$(dpkg-deb -f "${PACKAGE}" Recommends)
+            if [[ "${DEPENDS}" != *"libpulse0"* ]]; then
+              echo "::error::DEB package is missing required PulseAudio runtime dependency"
+              exit 1
+            fi
+            if [[ "${RECOMMENDS}" != *"libpipewire-0.3-0"* ]]; then
+              echo "::error::DEB package is missing recommended PipeWire fallback dependency"
+              exit 1
+            fi
+            ;;
           RPM) rpm -qpi "${PACKAGE}" ;;
         esac
         echo "::endgroup::"

--- a/.github/actions/build/distro/debian-12.sh
+++ b/.github/actions/build/distro/debian-12.sh
@@ -24,5 +24,5 @@ else
     echo "CPACK_DEBIAN_PACKAGE_SHLIBDEPS=OFF" >> "${GITHUB_ENV}"
 fi
 
-echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp25, libcurl4, zlib1g" >> "${GITHUB_ENV}"
-echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0 | libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp25, libcurl4, zlib1g, libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0" >> "${GITHUB_ENV}"

--- a/.github/actions/build/distro/debian-13.sh
+++ b/.github/actions/build/distro/debian-13.sh
@@ -23,7 +23,7 @@ else
     echo "CPACK_DEBIAN_PACKAGE_SHLIBDEPS=OFF" >> "${GITHUB_ENV}"
 fi
 
-# SHLIBDEPS=ON 时 Depends 由 dpkg-shlibdeps 计算（覆盖此值）；
+# SHLIBDEPS=ON 时，dpkg-shlibdeps 自动计算的 Depends 会与此值合并；
 # trixie 的 jsoncpp soname 已升至 26（libjsoncpp26，不同于 bookworm 的 libjsoncpp25）
-echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp26, libcurl4t64, zlib1g" >> "${GITHUB_ENV}"
-echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0 | libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp26, libcurl4t64, zlib1g, libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0" >> "${GITHUB_ENV}"

--- a/.github/actions/build/distro/fedora-44.sh
+++ b/.github/actions/build/distro/fedora-44.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fedora 44 bootstrap. 仓库自带 onnxruntime 1.22.2（单包，含头文件）→ system 策略。
-# RPM 运行时依赖由 rpmbuild 自动生成（.so SONAME → 提供包），无需手工维护。
+# 录音库通过 dlopen 加载，rpmbuild 无法从 ELF 自动推导其运行时依赖。
 set -euo pipefail
 
 if [ "$(id -u)" -eq 0 ]; then
@@ -20,3 +20,5 @@ $RUN dnf install -y \
 if [ "${ONNX_STRATEGY:-download}" = "system" ]; then
     $RUN dnf install -y onnxruntime-devel
 fi
+
+echo "CPACK_RPM_PACKAGE_REQUIRES=pulseaudio-libs" >> "${GITHUB_ENV}"

--- a/.github/actions/build/distro/opensuse-tumbleweed.sh
+++ b/.github/actions/build/distro/opensuse-tumbleweed.sh
@@ -22,3 +22,5 @@ $RUN zypper --non-interactive install -y \
 if [ "${ONNX_STRATEGY:-download}" = "system" ]; then
     $RUN zypper --non-interactive install -y onnxruntime-devel
 fi
+
+echo "CPACK_RPM_PACKAGE_REQUIRES=libpulse0" >> "${GITHUB_ENV}"

--- a/.github/actions/build/distro/ubuntu-24.04.sh
+++ b/.github/actions/build/distro/ubuntu-24.04.sh
@@ -26,5 +26,5 @@ else
 fi
 
 # t64 迁移后的运行时包名（Ubuntu 24.04 起 libcurl4t64；libjsoncpp25 为 jsoncpp soname）
-echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp25, libcurl4t64, zlib1g" >> "${GITHUB_ENV}"
-echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0 | libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp25, libcurl4t64, zlib1g, libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0" >> "${GITHUB_ENV}"

--- a/.github/actions/build/distro/ubuntu-26.04.sh
+++ b/.github/actions/build/distro/ubuntu-26.04.sh
@@ -24,7 +24,7 @@ else
     echo "CPACK_DEBIAN_PACKAGE_SHLIBDEPS=OFF" >> "${GITHUB_ENV}"
 fi
 
-# SHLIBDEPS=ON 时 Depends 由 dpkg-shlibdeps 计算（覆盖此值），此处仅作兜底；
+# SHLIBDEPS=ON 时，dpkg-shlibdeps 自动计算的 Depends 会与此值合并；
 # 注意 Ubuntu 26.04 jsoncpp soname 升至 26（libjsoncpp26，不同于 24.04 的 libjsoncpp25）
-echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp26, libcurl4t64, zlib1g" >> "${GITHUB_ENV}"
-echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0 | libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_DEPENDS=fcitx5, libjsoncpp26, libcurl4t64, zlib1g, libpulse0" >> "${GITHUB_ENV}"
+echo "CPACK_DEBIAN_PACKAGE_RECOMMENDS=libpipewire-0.3-0" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
           onnx_strategy: download
           run_verify: "true"
 
-  # 回归防护：录音后端为可选依赖（CMake QUIET 探测），
-  # 确保缺失任一后端时仍能构建，且产物不引用缺失库的符号。
+  # 回归防护：PulseAudio 是必需基线，PipeWire 为可选回退，
+  # 确保缺失 PipeWire 时仍能构建，且产物不引用 PipeWire 符号。
   build-no-pipewire:
     name: build without PipeWire
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,10 +290,11 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF CACHE BOOL "Compute DEB dependencies with
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/devcxl/fcitx5-voice-input")
 
 # RPM package（Fedora/openSUSE，cpack -G RPM）
-# 运行时依赖由 rpmbuild 自动生成（.so SONAME → 提供包），无需手工维护
+# dlopen 加载的录音库不会形成 ELF 依赖，由 CI 按发行版注入运行时包名。
 set(CPACK_RPM_FILE_NAME RPM-DEFAULT) # fcitx5-voice-input-0.4.0-1.x86_64.rpm
 set(CPACK_RPM_PACKAGE_LICENSE "LGPL-3.0-or-later")
 set(CPACK_RPM_PACKAGE_GROUP "Unspecified")
 set(CPACK_RPM_PACKAGE_RELEASE "1")
+set(CPACK_RPM_PACKAGE_REQUIRES "" CACHE STRING "RPM runtime dependencies (per-distro, set by CI)")
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,24 +35,17 @@ else()
     set(FCITX5_ADDON_DIR "lib/fcitx5")
 endif()
 
-# PipeWire audio capture (optional — 缺失时仅失去该后端，不影响其余功能)
+# PulseAudio 采集是必需基线，也兼容现代 PipeWire 桌面的 pipewire-pulse 服务。
+pkg_check_modules(PULSE REQUIRED libpulse-simple libpulse)
+
+# PipeWire 直连采集是可选运行时回退。
 pkg_check_modules(PIPEWIRE QUIET pipewire-0.3)
 if(NOT PIPEWIRE_FOUND)
     pkg_check_modules(PIPEWIRE QUIET libpipewire-0.3)
 endif()
 
-# PulseAudio fallback capture (optional — 缺失时仅失去该后端，不影响其余功能)
-pkg_check_modules(PULSE QUIET libpulse-simple libpulse)
-
-# 至少需要一个录音后端，否则 addon 无录音能力
-if(NOT PIPEWIRE_FOUND AND NOT PULSE_FOUND)
-    message(FATAL_ERROR "No audio capture backend found. Install at least one of: pipewire-0.3 (libpipewire-0.3-dev) or libpulse-simple (libpulse-dev)")
-endif()
 if(NOT PIPEWIRE_FOUND)
     message(WARNING "PipeWire not found — building without PipeWire capture backend")
-endif()
-if(NOT PULSE_FOUND)
-    message(WARNING "PulseAudio not found — building without PulseAudio capture backend")
 endif()
 
 # JSON parsing
@@ -124,13 +117,11 @@ set(ADDON_SOURCES
     src/addon/llm/llm_client.cpp
 )
 
-# 按可用性加入录音后端（可选依赖）
+# PipeWire 仅在可用时编入；PulseAudio 是必需基线。
 if(PIPEWIRE_FOUND)
     list(APPEND ADDON_SOURCES src/addon/capture/pipewire_capture.cpp)
 endif()
-if(PULSE_FOUND)
-    list(APPEND ADDON_SOURCES src/addon/capture/pulse_audio_capture.cpp)
-endif()
+list(APPEND ADDON_SOURCES src/addon/capture/pulse_audio_capture.cpp)
 
 set(ADDON_HEADERS
     src/addon/engine.h
@@ -152,13 +143,11 @@ set(ADDON_HEADERS
     src/addon/asr/utils/base64.h
 )
 
-# 头文件仅用于 IDE 索引，同样按可用性追加
+# 头文件仅用于 IDE 索引；PipeWire 按可用性追加。
 if(PIPEWIRE_FOUND)
     list(APPEND ADDON_HEADERS src/addon/capture/pipewire_capture.h)
 endif()
-if(PULSE_FOUND)
-    list(APPEND ADDON_HEADERS src/addon/capture/pulse_audio_capture.h)
-endif()
+list(APPEND ADDON_HEADERS src/addon/capture/pulse_audio_capture.h)
 
 # ─── Library ──────────────────────────────────────────────────────────────────
 add_library(voice-input-addon MODULE ${ADDON_SOURCES} ${ADDON_HEADERS})
@@ -179,9 +168,7 @@ target_include_directories(voice-input-addon PRIVATE
 if(PIPEWIRE_FOUND)
     target_include_directories(voice-input-addon PRIVATE ${PIPEWIRE_INCLUDE_DIRS})
 endif()
-if(PULSE_FOUND)
-    target_include_directories(voice-input-addon PRIVATE ${PULSE_INCLUDE_DIRS})
-endif()
+target_include_directories(voice-input-addon PRIVATE ${PULSE_INCLUDE_DIRS})
 
 target_link_libraries(voice-input-addon PRIVATE
     ${FCITX5_LIBRARIES}
@@ -200,9 +187,7 @@ target_compile_definitions(voice-input-addon PRIVATE
 if(PIPEWIRE_FOUND)
     target_compile_definitions(voice-input-addon PRIVATE HAVE_PIPEWIRE)
 endif()
-if(PULSE_FOUND)
-    target_compile_definitions(voice-input-addon PRIVATE HAVE_PULSEAUDIO)
-endif()
+target_compile_definitions(voice-input-addon PRIVATE HAVE_PULSEAUDIO)
 
 # ─── Translations ────────────────────────────────────────────────────────────
 find_program(GETTEXT_MSGFMT msgfmt REQUIRED)
@@ -298,10 +283,9 @@ set(CPACK_DEBIAN_PACKAGE_SECTION "libs")
 #   开启 SHLIBDEPS，由 dpkg-shlibdeps 自动计算运行时依赖；
 # - onnxruntime 不在仓库的发行版（Ubuntu 24.04/Debian 12，CI 下载 upstream
 #   release 包）无法声明 Depends，DEB 用户需自行安装 onnxruntime 运行时。
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "fcitx5, libjsoncpp25, libcurl4t64, zlib1g" CACHE STRING "DEB runtime dependencies (per-distro, set by CI)")
-# 录音后端为可选运行时依赖：Recommends 二选一（Ubuntu/Debian 运行时包名），
-# 与 CMake 构建期的可选探测保持一致——缺任一后端时包仍可安装使用另一个
-set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libpipewire-0.3-0 | libpulse0" CACHE STRING "DEB recommended capture backends (per-distro, set by CI)")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "fcitx5, libjsoncpp25, libcurl4t64, zlib1g, libpulse0" CACHE STRING "DEB runtime dependencies (per-distro, set by CI)")
+# PulseAudio 客户端库是基础录音能力的必需依赖；PipeWire 直连仅作可选回退。
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libpipewire-0.3-0" CACHE STRING "DEB optional PipeWire capture fallback (per-distro, set by CI)")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF CACHE BOOL "Compute DEB dependencies with dpkg-shlibdeps (ON when onnxruntime is a system package)")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/devcxl/fcitx5-voice-input")
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -14,13 +14,13 @@ depends=(
     'curl'
     'onnxruntime-cpu'
     'zlib'
+    'libpulse'
 )
-# 录音后端为可选依赖，至少安装其一（都不装则无法录音）
+# PipeWire 为 PulseAudio 基线失败时的可选直连回退。
 optdepends=(
-    'pipewire: PipeWire capture backend (required for recording)'
-    'libpulse: PulseAudio capture backend (required for recording)'
+    'pipewire: PipeWire direct capture fallback backend'
 )
-makedepends=('cmake' 'pkg-config' 'gettext')
+makedepends=('cmake' 'pkg-config' 'gettext' 'pipewire')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/devcxl/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Closes #26

## 变更
- 将 PulseAudio 设为构建和运行时的必需录音基线。
- 保持 PipeWire 直连为可选回退，缺失其开发包仍可构建。
- 对齐 DEB/AUR 依赖声明，并在 CI 断言包元数据。

## 验证
- 正常 CMake Release 构建成功。
- 关闭 PipeWire 探测的构建成功，产物仅编入 PulseAudio 后端且无 PipeWire 未定义符号。
- 普通与 CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON 的 DEB 均为 Depends: libpulse0、Recommends: libpipewire-0.3-0。
- makepkg --printsrcinfo 与相关 shell 脚本语法检查通过。
- git diff --check 通过。