### PR TITLE
fix(asr): preserve utterance result order

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -82,6 +82,7 @@ runs:
         cmake -B build
         -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}
         -DCMAKE_INSTALL_PREFIX=/usr
+        -DBUILD_TESTS=${{ inputs.run_verify }}
         -DONNXRUNTIME_ROOT="${ONNXRUNTIME_ROOT:-}"
         -DCMAKE_MODULE_LINKER_FLAGS="-Wl,-z,now"
         -DCPACK_DEBIAN_PACKAGE_DEPENDS="${CPACK_DEBIAN_PACKAGE_DEPENDS:-}"
@@ -92,6 +93,11 @@ runs:
     - name: Compile
       shell: bash
       run: cmake --build build -j"$(nproc)"
+
+    - name: Run tests
+      if: inputs.run_verify == 'true'
+      shell: bash
+      run: ctest --test-dir build --output-on-failure
 
     # The capture libraries are intentionally runtime-loaded. Build success alone
     # does not catch a direct pw_*/pa_* reference: with DF_1_NOW it only fails

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(ADDON_SOURCES
     src/addon/vad/vad.cpp
     src/addon/vad/silero_vad.cpp
     src/addon/pipeline/pipeline.cpp
+    src/addon/pipeline/result_coordinator.cpp
     src/addon/asr/openai_asr.cpp
     src/addon/asr/realtime_asr.cpp
     src/addon/asr/volcengine_asr.cpp
@@ -133,6 +134,8 @@ set(ADDON_HEADERS
     src/addon/asr/asr_engine.h
     src/addon/asr/asr_session.h
     src/addon/asr/session_reaper.h
+    src/addon/pipeline/ordered_result_buffer.h
+    src/addon/pipeline/result_coordinator.h
     src/addon/asr/openai_asr.h
     src/addon/asr/realtime_asr.h
     src/addon/asr/volcengine_asr.h

--- a/src/addon/asr/asr_engine.h
+++ b/src/addon/asr/asr_engine.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -15,6 +16,8 @@ namespace fcitx {
 /// 内部用 weak_ptr 追踪活跃 Session，用于批量取消。
 class AsrEngine {
 public:
+    static constexpr size_t kMaxActiveSessions = 3;
+
     struct Config {
         // Common
         std::string modelName;
@@ -51,7 +54,7 @@ public:
     /// 调用时若有活跃 Session，调用方应先 CancelAllSessions。
     virtual bool Init(const Config& config) = 0;
 
-    /// 创建新识别会话。返回 shared_ptr。
+    /// 创建新识别会话。返回 shared_ptr，调用方完成回调登记后再启动 worker。
     /// 超过 maxActiveSessions 时自动取消最旧会话。
     /// 若旧会话未结束，内部调用 Cancel（不阻塞）。
     virtual std::shared_ptr<AsrSession> StartSession() = 0;
@@ -65,13 +68,44 @@ public:
     void SetErrorCallback(AsrSession::ErrorCallback cb) { errorCb_ = std::move(cb); }
 
 protected:
+    std::optional<uint64_t> CancelOldestSessionIfLimitReachedLocked() {
+        for (auto it = sessions_.begin(); it != sessions_.end();) {
+            if (it->second.expired()) {
+                it = sessions_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        if (sessions_.size() < maxActiveSessions_) {
+            return std::nullopt;
+        }
+
+        auto oldest = sessions_.begin();
+        for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
+            auto session = it->second.lock();
+            auto oldestSession = oldest->second.lock();
+            if (session && (!oldestSession ||
+                            session->GetState()->sessionId <
+                                oldestSession->GetState()->sessionId)) {
+                oldest = it;
+            }
+        }
+
+        const auto sessionId = oldest->first;
+        if (auto session = oldest->second.lock()) {
+            session->Cancel();
+        }
+        sessions_.erase(oldest);
+        return sessionId;
+    }
+
     AsrSession::ResultCallback resultCb_;
     AsrSession::ErrorCallback errorCb_;
 
     std::mutex sessionsMutex_;
     std::unordered_map<uint64_t, std::weak_ptr<AsrSession>> sessions_;
     uint64_t nextSessionId_{1};
-    size_t maxActiveSessions_{3};
+    size_t maxActiveSessions_{kMaxActiveSessions};
 };
 
 } // namespace fcitx

--- a/src/addon/asr/asr_engine.h
+++ b/src/addon/asr/asr_engine.h
@@ -5,14 +5,18 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "asr_session.h"
 
 namespace fcitx {
 
+struct AsrSessionStart {
+    std::shared_ptr<AsrSession> session;
+    std::optional<uint64_t> cancelledSessionId;
+};
+
 /// ASR 后端引擎，全局单例（由 Pipeline 持有）。
-/// 工厂模式：StartSession() 返回独立会话对象。
+/// 工厂模式：StartSession() 返回独立会话及容量取消结果。
 /// 内部用 weak_ptr 追踪活跃 Session，用于批量取消。
 class AsrEngine {
 public:
@@ -54,10 +58,9 @@ public:
     /// 调用时若有活跃 Session，调用方应先 CancelAllSessions。
     virtual bool Init(const Config& config) = 0;
 
-    /// 创建新识别会话。返回 shared_ptr，调用方完成回调登记后再启动 worker。
-    /// 超过 maxActiveSessions 时自动取消最旧会话。
-    /// 若旧会话未结束，内部调用 Cancel（不阻塞）。
-    virtual std::shared_ptr<AsrSession> StartSession() = 0;
+    /// 创建新识别会话；若容量已满，同时返回实际取消的旧会话 ID。
+    /// 调用方完成 session 映射和回调登记后再启动 worker。
+    virtual AsrSessionStart StartSession() = 0;
 
     /// 取消所有由本 Engine 创建的活跃 Session。
     virtual void CancelAllSessions();

--- a/src/addon/asr/asr_engine.h
+++ b/src/addon/asr/asr_engine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -71,6 +72,10 @@ public:
     void SetErrorCallback(AsrSession::ErrorCallback cb) { errorCb_ = std::move(cb); }
 
 protected:
+    static uint64_t NextSessionId() {
+        return nextSessionId_.fetch_add(1, std::memory_order_relaxed);
+    }
+
     std::optional<uint64_t> CancelOldestSessionIfLimitReachedLocked() {
         for (auto it = sessions_.begin(); it != sessions_.end();) {
             if (it->second.expired()) {
@@ -107,8 +112,10 @@ protected:
 
     std::mutex sessionsMutex_;
     std::unordered_map<uint64_t, std::weak_ptr<AsrSession>> sessions_;
-    uint64_t nextSessionId_{1};
     size_t maxActiveSessions_{kMaxActiveSessions};
+
+private:
+    inline static std::atomic<uint64_t> nextSessionId_{1};
 };
 
 } // namespace fcitx

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -353,7 +353,7 @@ AsrSessionStart OpenaiAsrEngine::StartSession() {
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
-        sid = nextSessionId_++;
+        sid = NextSessionId();
     }
 
     auto session = std::make_shared<OpenaiAsrSession>(

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -347,14 +347,12 @@ bool OpenaiAsrEngine::Init(const Config& config) {
     return true;
 }
 
-std::shared_ptr<AsrSession> OpenaiAsrEngine::StartSession() {
+AsrSessionStart OpenaiAsrEngine::StartSession() {
     uint64_t sid;
+    std::optional<uint64_t> cancelledSessionId;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
-        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
-            FCITX_WARN() << "[voice-input:openai] Too many sessions, cancel oldest="
-                         << *cancelled;
-        }
+        cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
         sid = nextSessionId_++;
     }
 
@@ -366,7 +364,7 @@ std::shared_ptr<AsrSession> OpenaiAsrEngine::StartSession() {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         sessions_[sid] = session;
     }
-    return session;
+    return {std::move(session), cancelledSessionId};
 }
 
 } // namespace fcitx

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -351,14 +351,16 @@ std::shared_ptr<AsrSession> OpenaiAsrEngine::StartSession() {
     uint64_t sid;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
+        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
+            FCITX_WARN() << "[voice-input:openai] Too many sessions, cancel oldest="
+                         << *cancelled;
+        }
         sid = nextSessionId_++;
     }
 
     auto session = std::make_shared<OpenaiAsrSession>(
         config_, errorCb_, sid);
     session->SetResultCallback(resultCb_);
-    if (!session->GetState()->finished)
-        session->StartWorker();
 
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);

--- a/src/addon/asr/openai_asr.h
+++ b/src/addon/asr/openai_asr.h
@@ -40,7 +40,7 @@ private:
 class OpenaiAsrEngine : public AsrEngine {
 public:
     bool Init(const Config& config) override;
-    std::shared_ptr<AsrSession> StartSession() override;
+    AsrSessionStart StartSession() override;
     const char* Name() const override { return "openai-compat"; }
 
 private:

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -512,7 +512,7 @@ AsrSessionStart RealtimeAsrEngine::StartSession() {
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
-        sid = nextSessionId_++;
+        sid = NextSessionId();
     }
 
     auto session = std::make_shared<RealtimeAsrSession>(config_, errorCb_, sid);

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -496,18 +496,15 @@ std::shared_ptr<AsrSession> RealtimeAsrEngine::StartSession() {
     uint64_t sid;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
-        // 清理过期 weak_ptr，避免长期运行 map 无限增长
-        for (auto it = sessions_.begin(); it != sessions_.end(); ) {
-            if (it->second.expired()) it = sessions_.erase(it);
-            else ++it;
+        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
+            FCITX_WARN() << "[voice-input:realtime] Too many sessions, cancel oldest="
+                         << *cancelled;
         }
         sid = nextSessionId_++;
     }
 
     auto session = std::make_shared<RealtimeAsrSession>(config_, errorCb_, sid);
     session->SetResultCallback(resultCb_);
-    if (!session->GetState()->finished)
-        session->StartWorker();
 
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -243,20 +243,25 @@ void RealtimeAsrSession::WorkerLoop() {
         return JsonToString(ev);
     };
 
-    bool gotFinal = false;
+    RealtimeTerminalState terminal;
+    auto publishFinal = [&](const std::string& transcript) {
+        if (!terminal.TryMarkPublished()) return;
+        if (cb) cb(transcript, true, sid);
+    };
     bool endCommitSent = false;      // End commit 是否已发出（决定最终 item 判定）
     std::string fullTranscript;      // 会话级累积文本（整句，preedit 显示的依据）
     std::string currentTranscript;   // 当前 item 的 delta 累积
     std::vector<int16_t> pending24k;  // 提升到连接循环外，重连时保留未发送缓冲
 
     // 连接循环：处理首次连接 + 断线/30min 重连（保持同一 sessionId）
-    for (int attempt = 0; attempt < kMaxReconnectAttempts && !gotFinal; ++attempt) {
+    for (int attempt = 0;
+         attempt < kMaxReconnectAttempts && !terminal.IsPublished(); ++attempt) {
         if (state_->cancelled) break;
 
         CURL* curl = curl_easy_init();
         if (!curl) {
             if (ecb) ecb("Failed to init curl");
-            if (cb) cb("", true, sid);
+            publishFinal({});
             return;
         }
 
@@ -289,7 +294,7 @@ void RealtimeAsrSession::WorkerLoop() {
             curl_easy_cleanup(curl);
             if (attempt == kMaxReconnectAttempts - 1) {
                 if (ecb) ecb("Realtime connect failed: " + std::string(curl_easy_strerror(connectResult)));
-                if (cb) cb("", true, sid);
+                publishFinal({});
                 return;
             }
             std::this_thread::sleep_for(1s);
@@ -307,15 +312,21 @@ void RealtimeAsrSession::WorkerLoop() {
         int commitsInFlight = 0;           // 在途 commit 数（重连后新连接重新计数）
 
         // 处理服务端事件
-        auto handleServer = [&](std::chrono::milliseconds timeout) {
+        auto handleServer = [&](std::chrono::milliseconds timeout)
+            -> RealtimeServerOutcome {
             auto deadline = std::chrono::steady_clock::now() + timeout;
-            while (!state_->cancelled && !gotFinal &&
+            while (!state_->cancelled && !terminal.IsPublished() &&
                    std::chrono::steady_clock::now() < deadline) {
                 std::string text;
                 RecvStatus r = ReceiveTextFrame(curl, text);
                 if (r == RecvStatus::Again) { std::this_thread::sleep_for(10ms); continue; }
-                if (r == RecvStatus::Closed) { gotFinal = true; return false; }
-                if (r == RecvStatus::Error) { if (ecb) ecb("WS recv error"); return false; }
+                if (r == RecvStatus::Closed) {
+                    return RealtimeServerOutcome::TransportFailure;
+                }
+                if (r == RecvStatus::Error) {
+                    if (ecb) ecb("WS recv error");
+                    return RealtimeServerOutcome::TransportFailure;
+                }
 
                 Json::Value json;
                 Json::Reader reader;
@@ -338,10 +349,9 @@ void RealtimeAsrSession::WorkerLoop() {
                     fullTranscript += transcript;
                     if (isFinalItem) {
                         // 最终结果（整句累积），上报 final 并结束会话
-                        if (cb && !fullTranscript.empty()) cb(fullTranscript, true, sid);
+                        publishFinal(fullTranscript);
                         currentTranscript.clear();
-                        gotFinal = true;
-                        return false;
+                        return RealtimeServerOutcome::FinalReceived;
                     } else {
                         // 周期 commit（或在途旧 item）产生的转录 → 累加后作为 partial 刷新 preedit
                         // （pipeline 契约：每个会话仅一个 final，此处不得上报 final）
@@ -355,11 +365,12 @@ void RealtimeAsrSession::WorkerLoop() {
                 }
                 // 其他事件（response.*/error 等）忽略
             }
-            return true;
+            return RealtimeServerOutcome::Continue;
         };
 
         bool reconnectNeeded = false;
-        while (!state_->cancelled && !gotFinal && !reconnectNeeded) {
+        while (!state_->cancelled && !terminal.IsPublished() &&
+               !reconnectNeeded) {
             std::vector<int16_t> chunk;
             bool hasChunk = audioChunks->TryPop(chunk);
 
@@ -372,31 +383,31 @@ void RealtimeAsrSession::WorkerLoop() {
                     if (!SendWebSocketText(curl, buildAppendEvent(pending24k), state_->cancelled)) {
                         FCITX_ERROR() << "[voice-input:realtime] End flush failed session=" << sid;
                         // 兜底 final 后经统一清理路径退出（break → CloseWebSocket + cleanup）
-                        if (cb) cb(fullTranscript, true, sid);
-                        gotFinal = true;
+                        publishFinal(fullTranscript);
                         break;
                     }
                     pending24k.clear();
                 }
                 if (!SendWebSocketText(curl, buildCommitEvent(), state_->cancelled)) {
                     FCITX_ERROR() << "[voice-input:realtime] End commit failed session=" << sid;
-                    if (cb) cb(fullTranscript, true, sid);
-                    gotFinal = true;
+                    publishFinal(fullTranscript);
                     break;
                 }
                 endCommitSent = true;
                 ++commitsInFlight;
                 auto deadline = std::chrono::steady_clock::now() + 30s;
-                while (!state_->cancelled && !gotFinal &&
+                while (!state_->cancelled && !terminal.IsPublished() &&
                        std::chrono::steady_clock::now() < deadline) {
-                    if (!handleServer(50ms)) { gotFinal = true; break; }
+                    const auto decision = DecideRealtimeServerOutcome(
+                        handleServer(50ms), true);
+                    if (decision.publishFallback) publishFinal(fullTranscript);
+                    if (decision.stop) break;
                 }
-                if (!gotFinal && !state_->cancelled) {
+                if (!terminal.IsPublished() && !state_->cancelled) {
                     // 30s 超时仍未收到最终 completed → 以已累积文本兜底 final，
-                    // 并置 gotFinal 结束会话（否则 for 循环会重连后空转挂死）
+                    // 并结束会话（否则 for 循环会重连后空转挂死）。
                     FCITX_WARN() << "[voice-input:realtime] End wait timeout session=" << sid;
-                    if (cb) cb(fullTranscript, true, sid);
-                    gotFinal = true;
+                    publishFinal(fullTranscript);
                 }
                 break;
             }
@@ -457,14 +468,17 @@ void RealtimeAsrSession::WorkerLoop() {
                 break;
             }
 
-            if (!handleServer(20ms)) { gotFinal = true; break; }
+            const auto decision =
+                DecideRealtimeServerOutcome(handleServer(20ms), false);
+            if (decision.reconnect) reconnectNeeded = true;
+            if (decision.stop || decision.reconnect) break;
             std::this_thread::sleep_for(5ms);
         }
 
         CloseWebSocket(curl);
         curl_easy_cleanup(curl);
 
-        if (state_->cancelled || gotFinal) break;
+        if (state_->cancelled || terminal.IsPublished()) break;
         if (reconnectNeeded) {
             FCITX_WARN() << "[voice-input:realtime] Reconnecting session=" << sid;
             // 重连后是全新服务端会话，旧 item 的 delta 上下文已失效：
@@ -479,9 +493,9 @@ void RealtimeAsrSession::WorkerLoop() {
         FCITX_DEBUG() << "[voice-input:realtime] Cancelled session=" << sid;
         return;
     }
-    if (!gotFinal) {
+    if (!terminal.IsPublished()) {
         // 未收到最终转录（连接断开/失败）：以空 final 触发 pipeline 错误/清理分支
-        if (cb) cb("", true, sid);
+        publishFinal({});
     }
 }
 
@@ -492,14 +506,12 @@ bool RealtimeAsrEngine::Init(const Config& config) {
     return true;
 }
 
-std::shared_ptr<AsrSession> RealtimeAsrEngine::StartSession() {
+AsrSessionStart RealtimeAsrEngine::StartSession() {
     uint64_t sid;
+    std::optional<uint64_t> cancelledSessionId;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
-        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
-            FCITX_WARN() << "[voice-input:realtime] Too many sessions, cancel oldest="
-                         << *cancelled;
-        }
+        cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
         sid = nextSessionId_++;
     }
 
@@ -510,7 +522,7 @@ std::shared_ptr<AsrSession> RealtimeAsrEngine::StartSession() {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         sessions_[sid] = session;
     }
-    return session;
+    return {std::move(session), cancelledSessionId};
 }
 
 } // namespace fcitx

--- a/src/addon/asr/realtime_asr.h
+++ b/src/addon/asr/realtime_asr.h
@@ -14,6 +14,46 @@
 
 namespace fcitx {
 
+enum class RealtimeServerOutcome {
+    Continue,
+    FinalReceived,
+    TransportFailure,
+};
+
+struct RealtimeServerDecision {
+    bool stop = false;
+    bool reconnect = false;
+    bool publishFallback = false;
+};
+
+constexpr RealtimeServerDecision DecideRealtimeServerOutcome(
+    RealtimeServerOutcome outcome, bool inputFinished) {
+    if (outcome == RealtimeServerOutcome::FinalReceived) {
+        return {.stop = true};
+    }
+    if (outcome == RealtimeServerOutcome::TransportFailure) {
+        return inputFinished
+                   ? RealtimeServerDecision{.stop = true,
+                                            .publishFallback = true}
+                   : RealtimeServerDecision{.reconnect = true};
+    }
+    return {};
+}
+
+class RealtimeTerminalState {
+public:
+    bool TryMarkPublished() {
+        if (published_) return false;
+        published_ = true;
+        return true;
+    }
+
+    bool IsPublished() const { return published_; }
+
+private:
+    bool published_ = false;
+};
+
 /// OpenAI Realtime 流式实时转录会话。
 ///
 /// 与 VolcengineAsrSession 结构对齐：StartWorker 即建 WS 持久连接，
@@ -51,7 +91,7 @@ private:
 class RealtimeAsrEngine : public AsrEngine {
 public:
     bool Init(const Config& config) override;
-    std::shared_ptr<AsrSession> StartSession() override;
+    AsrSessionStart StartSession() override;
     const char* Name() const override { return "realtime"; }
 
 private:

--- a/src/addon/asr/volcengine_asr.cpp
+++ b/src/addon/asr/volcengine_asr.cpp
@@ -612,38 +612,18 @@ bool VolcengineAsrEngine::Init(const Config& config) {
 }
 
 std::shared_ptr<AsrSession> VolcengineAsrEngine::StartSession() {
-    {
-        std::lock_guard<std::mutex> lock(sessionsMutex_);
-        // Clean expired weak_ptrs
-        for (auto it = sessions_.begin(); it != sessions_.end(); ) {
-            if (it->second.expired()) it = sessions_.erase(it);
-            else ++it;
-        }
-        // Enforce maxActiveSessions: cancel oldest
-        while (sessions_.size() >= maxActiveSessions_) {
-            auto oldest = sessions_.begin();
-            for (auto it = sessions_.begin(); it != sessions_.end(); ++it) {
-                auto s = it->second.lock();
-                auto o = oldest->second.lock();
-                if (s && (!o || s->GetState()->sessionId < o->GetState()->sessionId))
-                    oldest = it;
-            }
-            auto s = oldest->second.lock();
-            if (s) { FCITX_WARN() << "[voice-input:volcengine] Too many sessions, cancel oldest"; s->Cancel(); }
-            sessions_.erase(oldest);
-        }
-    }
-
     uint64_t sid;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
+        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
+            FCITX_WARN() << "[voice-input:volcengine] Too many sessions, cancel oldest="
+                         << *cancelled;
+        }
         sid = nextSessionId_++;
     }
 
     auto session = std::make_shared<VolcengineAsrSession>(config_, errorCb_, sid);
     session->SetResultCallback(resultCb_);
-    if (!session->GetState()->finished)
-        session->StartWorker();
 
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);

--- a/src/addon/asr/volcengine_asr.cpp
+++ b/src/addon/asr/volcengine_asr.cpp
@@ -617,7 +617,7 @@ AsrSessionStart VolcengineAsrEngine::StartSession() {
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
-        sid = nextSessionId_++;
+        sid = NextSessionId();
     }
 
     auto session = std::make_shared<VolcengineAsrSession>(config_, errorCb_, sid);

--- a/src/addon/asr/volcengine_asr.cpp
+++ b/src/addon/asr/volcengine_asr.cpp
@@ -611,14 +611,12 @@ bool VolcengineAsrEngine::Init(const Config& config) {
     return true;
 }
 
-std::shared_ptr<AsrSession> VolcengineAsrEngine::StartSession() {
+AsrSessionStart VolcengineAsrEngine::StartSession() {
     uint64_t sid;
+    std::optional<uint64_t> cancelledSessionId;
     {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
-        if (auto cancelled = CancelOldestSessionIfLimitReachedLocked()) {
-            FCITX_WARN() << "[voice-input:volcengine] Too many sessions, cancel oldest="
-                         << *cancelled;
-        }
+        cancelledSessionId = CancelOldestSessionIfLimitReachedLocked();
         sid = nextSessionId_++;
     }
 
@@ -629,7 +627,7 @@ std::shared_ptr<AsrSession> VolcengineAsrEngine::StartSession() {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         sessions_[sid] = session;
     }
-    return session;
+    return {std::move(session), cancelledSessionId};
 }
 
 } // namespace fcitx

--- a/src/addon/asr/volcengine_asr.h
+++ b/src/addon/asr/volcengine_asr.h
@@ -51,7 +51,7 @@ private:
 class VolcengineAsrEngine : public AsrEngine {
 public:
     bool Init(const Config& config) override;
-    std::shared_ptr<AsrSession> StartSession() override;
+    AsrSessionStart StartSession() override;
     const char* Name() const override { return "volcengine"; }
 
 private:

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -322,6 +322,7 @@ void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
     CURL* curl = curl_easy_init();
     if (!curl) {
         FCITX_ERROR() << "[voice-input:llm:stream] Failed to init curl";
+        onComplete(text);
         return;
     }
 
@@ -372,6 +373,13 @@ void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
                      << curl_easy_strerror(res)
                      << " http=" << httpCode
                      << " elapsed=" << elapsedMs << "ms";
+        onComplete(text);
+        return;
+    }
+    if (!ctx.done) {
+        FCITX_WARN() << "[voice-input:llm:stream] Response ended without [DONE], "
+                     << "falling back to raw ASR text";
+        onComplete(text);
         return;
     }
     if (!ctx.done) {

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -276,7 +276,7 @@ void LLMClient::Process(const std::string& text, uint64_t generation,
 }
 
 void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
-                               std::function<void(const std::string&)> onToken,
+                               std::function<void(const std::string&)>,
                                std::function<void(const std::string&)> onComplete) {
     if (config_.model.empty() || !onComplete) return;
 
@@ -322,7 +322,7 @@ void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
     CURL* curl = curl_easy_init();
     if (!curl) {
         FCITX_ERROR() << "[voice-input:llm:stream] Failed to init curl";
-        onComplete(text);
+        cancellationContext.PublishIfCurrent([&] { onComplete(text); });
         return;
     }
 
@@ -373,17 +373,13 @@ void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
                      << curl_easy_strerror(res)
                      << " http=" << httpCode
                      << " elapsed=" << elapsedMs << "ms";
-        onComplete(text);
+        cancellationContext.PublishIfCurrent([&] { onComplete(text); });
         return;
     }
     if (!ctx.done) {
         FCITX_WARN() << "[voice-input:llm:stream] Response ended without [DONE], "
                      << "falling back to raw ASR text";
-        onComplete(text);
-        return;
-    }
-    if (!ctx.done) {
-        FCITX_WARN() << "[voice-input:llm:stream] Response ended without [DONE]";
+        cancellationContext.PublishIfCurrent([&] { onComplete(text); });
         return;
     }
 

--- a/src/addon/pipeline/ordered_result_buffer.h
+++ b/src/addon/pipeline/ordered_result_buffer.h
@@ -27,6 +27,9 @@ public:
         }
 
         auto& pending = pending_[result.utteranceId];
+        if (pending.skipped) {
+            return {};
+        }
         if (result.isPartial && !pending.results.empty() &&
             pending.results.back().isPartial) {
             pending.results.back() = std::move(result);
@@ -43,7 +46,10 @@ public:
             return {};
         }
 
-        pending_[utteranceId].terminal = true;
+        auto& pending = pending_[utteranceId];
+        pending.results.clear();
+        pending.skipped = true;
+        pending.terminal = true;
         return DrainReadyLocked();
     }
 
@@ -51,6 +57,7 @@ private:
     struct PendingUtterance {
         std::deque<AsrResult> results;
         bool terminal = false;
+        bool skipped = false;
     };
 
     std::vector<AsrResult> DrainReadyLocked() {

--- a/src/addon/pipeline/ordered_result_buffer.h
+++ b/src/addon/pipeline/ordered_result_buffer.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "types.h"
+
+namespace fcitx {
+
+// 将并发 ASR 回调按语音段创建顺序交付给主线程。
+class OrderedResultBuffer {
+public:
+    void Reset(uint64_t firstUtteranceId) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pending_.clear();
+        nextUtteranceId_ = firstUtteranceId;
+    }
+
+    std::vector<AsrResult> Submit(AsrResult result, bool terminal) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (result.utteranceId < nextUtteranceId_) {
+            return {};
+        }
+
+        auto& pending = pending_[result.utteranceId];
+        if (result.isPartial && !pending.results.empty() &&
+            pending.results.back().isPartial) {
+            pending.results.back() = std::move(result);
+        } else {
+            pending.results.push_back(std::move(result));
+        }
+        pending.terminal = pending.terminal || terminal;
+        return DrainReadyLocked();
+    }
+
+    std::vector<AsrResult> Skip(uint64_t utteranceId) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (utteranceId < nextUtteranceId_) {
+            return {};
+        }
+
+        pending_[utteranceId].terminal = true;
+        return DrainReadyLocked();
+    }
+
+private:
+    struct PendingUtterance {
+        std::deque<AsrResult> results;
+        bool terminal = false;
+    };
+
+    std::vector<AsrResult> DrainReadyLocked() {
+        std::vector<AsrResult> ready;
+        while (true) {
+            auto it = pending_.find(nextUtteranceId_);
+            if (it == pending_.end()) {
+                break;
+            }
+
+            auto& pending = it->second;
+            while (!pending.results.empty()) {
+                ready.push_back(std::move(pending.results.front()));
+                pending.results.pop_front();
+            }
+            if (!pending.terminal) {
+                break;
+            }
+
+            pending_.erase(it);
+            ++nextUtteranceId_;
+        }
+        return ready;
+    }
+
+    std::mutex mutex_;
+    std::map<uint64_t, PendingUtterance> pending_;
+    uint64_t nextUtteranceId_ = 1;
+};
+
+} // namespace fcitx

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -89,10 +89,10 @@ void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
     std::shared_ptr<AsrEngine> previousEngine;
     {
         std::lock_guard<std::mutex> lock(engineMutex_);
+        results_->SkipAllSessions();
         previousEngine = std::move(asrEngine_);
         asrEngine_ = std::move(enginePtr);
     }
-    results_->SkipAllSessions();
     if (previousEngine) previousEngine->CancelAllSessions();
 }
 

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -1,9 +1,7 @@
 #include "pipeline.h"
 
 #include <fcitx-utils/log.h>
-#include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <thread>
 
 #ifdef HAVE_PIPEWIRE
@@ -20,7 +18,8 @@ namespace fcitx {
 
 Pipeline::Pipeline()
     : vadWorker_(std::make_unique<VADWorker>())
-    , reaper_(std::make_unique<SessionReaper>()) {}
+    , reaper_(std::make_unique<SessionReaper>())
+    , results_(std::make_shared<ResultCoordinator>()) {}
 
 Pipeline::~Pipeline() {
     Abort();
@@ -70,183 +69,35 @@ void Pipeline::SetConfig(const VoiceInputConfig& config) {
 }
 
 void Pipeline::SetLLMClient(std::unique_ptr<LLMClient> client) {
-    llmClient_ = std::move(client);
-    if (llmClient_ && running_) {
-        llmClient_->Activate(generation_.load());
-    }
-}
-
-void Pipeline::SubmitOrderedResult(AsrResult result, bool terminal) {
-    std::string notificationText;
-    {
-        std::lock_guard<std::mutex> lock(orderedResultMutex_);
-        auto ready = orderedResults_.Submit(std::move(result), terminal);
-        if (ready.empty()) return;
-
-        notificationText = ready.back().text;
-        for (auto& item : ready) {
-            resultQueue_.Push(std::move(item));
-        }
-    }
-    if (resultCb_) {
-        resultCb_(notificationText);
-    }
-}
-
-void Pipeline::SkipUtterance(uint64_t utteranceId) {
-    std::string notificationText;
-    {
-        std::lock_guard<std::mutex> lock(orderedResultMutex_);
-        auto ready = orderedResults_.Skip(utteranceId);
-        if (ready.empty()) return;
-
-        notificationText = ready.back().text;
-        for (auto& item : ready) {
-            resultQueue_.Push(std::move(item));
-        }
-    }
-    if (resultCb_) {
-        resultCb_(notificationText);
-    }
-}
-
-void Pipeline::ResetOrderedResults() {
-    std::lock_guard<std::mutex> lock(orderedResultMutex_);
-    orderedResults_.Reset(utteranceCounter_.load() + 1);
+    results_->SetLLMClient(std::shared_ptr<LLMClient>(std::move(client)));
 }
 
 void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
     std::shared_ptr<AsrEngine> enginePtr = std::move(engine);
     if (enginePtr) {
+        auto results = results_;
         enginePtr->SetResultCallback(
-            [this, guard = resultGuard_](const std::string& text, bool isFinal,
-                                         uint64_t sid) {
-            // 会话 worker 线程可能晚于管线析构退出（reaper 超时 detach），
-            // 回调前检查守卫，避免访问已析构的 Pipeline。
-            if (!guard->load()) return;
-
-            // Look up generation captured at session start
-            SessionMetadata metadata;
-            {
-                std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                auto it = sessionGenerationMap_.find(sid);
-                if (it == sessionGenerationMap_.end()) return;
-                metadata = it->second;
-                if (isFinal) {
-                    sessionGenerationMap_.erase(sid);
-                }
-            }
-
-            if (isFinal) {
-                if (text.empty()) {
-                    AsrResult errorResult;
-                    errorResult.generation = metadata.generation;
-                    errorResult.sessionId = sid;
-                    errorResult.utteranceId = metadata.utteranceId;
-                    errorResult.isError = true;
-                    SubmitOrderedResult(std::move(errorResult), true);
-                    return;
-                }
-
-                AsrResult rawResult;
-                rawResult.text = text;
-                rawResult.generation = metadata.generation;
-                rawResult.sessionId = sid;
-                rawResult.utteranceId = metadata.utteranceId;
-                rawResult.isLLMRefined = false;
-                FCITX_DEBUG() << "[voice-input] ASR raw: uid="
-                             << metadata.utteranceId
-                             << " text=\"" << text << "\"";
-                SubmitOrderedResult(std::move(rawResult), !llmClient_);
-
-                if (llmClient_) {
-                    FCITX_DEBUG() << "[voice-input] LLM refine started"
-                                 << " uid=" << metadata.utteranceId
-                                 << " gen=" << metadata.generation
-                                 << " stream=" << llmStream_;
-                    if (llmStream_) {
-                        llmClient_->ProcessStream(text, metadata.generation,
-                            [this, guard, metadata,
-                             sid](const std::string& partial) {
-                                if (!guard->load()) return;
-                                AsrResult partialResult;
-                                partialResult.text = partial;
-                                partialResult.generation = metadata.generation;
-                                partialResult.sessionId = sid;
-                                partialResult.utteranceId = metadata.utteranceId;
-                                partialResult.isLLMRefined = true;
-                                partialResult.isPartial = true;
-                                SubmitOrderedResult(std::move(partialResult), false);
-                            },
-                            [this, guard, metadata,
-                             sid](const std::string& fullText) {
-                                if (!guard->load()) return;
-                                AsrResult finalResult;
-                                finalResult.text = fullText;
-                                finalResult.generation = metadata.generation;
-                                finalResult.sessionId = sid;
-                                finalResult.utteranceId = metadata.utteranceId;
-                                finalResult.isLLMRefined = true;
-                                finalResult.isPartial = false;
-                                SubmitOrderedResult(std::move(finalResult), true);
-                            });
-                    } else {
-                        llmClient_->Process(
-                            text, metadata.generation,
-                            [this, guard, metadata,
-                             sid](const std::string& processed) {
-                                if (!guard->load()) return;
-                                AsrResult refinedResult;
-                                refinedResult.text = processed;
-                                refinedResult.generation = metadata.generation;
-                                refinedResult.sessionId = sid;
-                                refinedResult.utteranceId = metadata.utteranceId;
-                                refinedResult.isLLMRefined = true;
-                                SubmitOrderedResult(std::move(refinedResult), true);
-                            });
-                    }
-                }
-            } else if (!text.empty()) {
-                AsrResult partial;
-                partial.text = text;
-                partial.generation = metadata.generation;
-                partial.sessionId = sid;
-                partial.utteranceId = metadata.utteranceId;
-                partial.isLLMRefined = false;
-                partial.isPartial = true;
-                SubmitOrderedResult(std::move(partial), false);
-            }
+            [results](const std::string& text, bool isFinal, uint64_t sid) {
+                results->HandleAsrResult(text, isFinal, sid);
             });
         enginePtr->SetErrorCallback(
-            [this, guard = resultGuard_](const std::string& error) {
-                if (!guard->load()) return;
+            [](const std::string& error) {
                 FCITX_ERROR() << "[voice-input] ASR error: " << error;
             });
     }
 
     std::shared_ptr<AsrEngine> previousEngine;
-    std::vector<uint64_t> skippedUtterances;
     {
-        // 与 Begin 的锁顺序一致：先 engineMutex_，后 sessionMapMutex_。
-        std::lock_guard<std::mutex> engineLock(engineMutex_);
+        std::lock_guard<std::mutex> lock(engineMutex_);
         previousEngine = std::move(asrEngine_);
         asrEngine_ = std::move(enginePtr);
-        std::lock_guard<std::mutex> sessionLock(sessionMapMutex_);
-        for (const auto& [sessionId, metadata] : sessionGenerationMap_) {
-            skippedUtterances.push_back(metadata.utteranceId);
-        }
-        sessionGenerationMap_.clear();
     }
-    if (previousEngine) {
-        previousEngine->CancelAllSessions();
-    }
-    for (uint64_t utteranceId : skippedUtterances) {
-        SkipUtterance(utteranceId);
-    }
+    results_->SkipAllSessions();
+    if (previousEngine) previousEngine->CancelAllSessions();
 }
 
 void Pipeline::SetResultCallback(ResultCallback cb) {
-    resultCb_ = std::move(cb);
+    results_->SetResultCallback(std::move(cb));
 }
 
 void Pipeline::SetVadStatusCallback(VADWorker::VadStatusCallback cb) {
@@ -255,7 +106,7 @@ void Pipeline::SetVadStatusCallback(VADWorker::VadStatusCallback cb) {
 
 void Pipeline::Start() {
     if (running_) {
-        if (llmClient_) llmClient_->Activate(generation_.load());
+        results_->Start(utteranceCounter_.load() + 1, generation_.load());
         return;
     }
 
@@ -266,21 +117,18 @@ void Pipeline::Start() {
 
     if (!StartCapture()) return;
 
-    // Drain stale results from previous session
-    AsrResult stale;
-    while (resultQueue_.TryPop(stale)) {}
-    ResetOrderedResults();
+    results_->Start(utteranceCounter_.load() + 1, generation_.load());
 
     vadWorker_->Start();
     if (!vadWorker_->IsRunning()) {
         // VAD 初始化失败（如模型缺失）：回滚 capture，避免无消费者推帧
         FCITX_ERROR() << "[voice-input] VAD failed to start, aborting";
+        results_->Pause(utteranceCounter_.load() + 1);
         capture_->Stop();
         capture_.reset();
         return;
     }
 
-    if (llmClient_) llmClient_->Activate(generation_.load());
     running_ = true;
     asrThread_ = std::make_unique<std::thread>(&Pipeline::AsrDispatcherLoop, this);
 
@@ -291,9 +139,7 @@ void Pipeline::Stop() {
     if (!running_) return;
 
     running_ = false;
-    if (llmClient_) {
-        llmClient_->Cancel();
-    }
+    results_->Pause(utteranceCounter_.load() + 1);
 
     if (capture_) {
         capture_->Stop();
@@ -327,27 +173,17 @@ void Pipeline::Stop() {
         capture_.reset();
     }
 
-    // Drain remaining results and audio queues（避免下次 Start 消费残留帧产生幽灵转写）
-    AsrResult r;
-    while (resultQueue_.TryPop(r)) {}
+    // Drain remaining audio queues（避免下次 Start 消费残留帧产生幽灵转写）
     AudioFrame f;
     while (frameQueue_.TryPop(f)) {}
     SpeechEvent se;
     while (speechEventQueue_.TryPop(se)) {}
-    {
-        std::lock_guard<std::mutex> lock(sessionMapMutex_);
-        sessionGenerationMap_.clear();
-    }
-    ResetOrderedResults();
-
     FCITX_INFO() << "[voice-input] Pipeline stopped";
 }
 
 void Pipeline::Abort() {
     running_ = false;
-    if (llmClient_) {
-        llmClient_->Cancel();
-    }
+    results_->Close(utteranceCounter_.load() + 1);
 
     if (capture_) {
         capture_->Stop();
@@ -381,12 +217,6 @@ void Pipeline::Abort() {
     while (frameQueue_.TryPop(f)) {}
     SpeechEvent se;
     while (speechEventQueue_.TryPop(se)) {}
-    AsrResult r;
-    while (resultQueue_.TryPop(r)) {}
-    ResetOrderedResults();
-
-    // 终态：回调守卫失效，引擎 worker 线程的异步回调全部丢弃
-    resultGuard_->store(false);
 }
 
 bool Pipeline::StartCapture() {
@@ -438,52 +268,22 @@ void Pipeline::AsrDispatcherLoop() {
             std::shared_ptr<AsrEngine> engine = asrEngine_;
             if (!engine) break;
             // Cancel current session if still active
-            uint64_t cancelledUtteranceId = 0;
             if (activeSession_) {
-                {
-                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                    auto it = sessionGenerationMap_.find(activeSessionId_);
-                    if (it != sessionGenerationMap_.end()) {
-                        cancelledUtteranceId = it->second.utteranceId;
-                        sessionGenerationMap_.erase(it);
-                    }
-                }
+                results_->SkipSession(activeSessionId_);
                 activeSession_->Cancel();
                 reaper_->Add(std::move(activeSession_));
                 activeSessionId_ = 0;
             }
-            if (cancelledUtteranceId != 0) {
-                SkipUtterance(cancelledUtteranceId);
-            }
-
-            uint64_t limitCancelledUtteranceId = 0;
-            uint64_t limitCancelledSessionId = 0;
-            {
-                std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                if (sessionGenerationMap_.size() >=
-                    AsrEngine::kMaxActiveSessions) {
-                    auto oldest = sessionGenerationMap_.begin();
-                    for (auto it = sessionGenerationMap_.begin();
-                         it != sessionGenerationMap_.end(); ++it) {
-                        if (it->second.utteranceId < oldest->second.utteranceId) {
-                            oldest = it;
-                        }
-                    }
-                    limitCancelledSessionId = oldest->first;
-                    limitCancelledUtteranceId = oldest->second.utteranceId;
-                    sessionGenerationMap_.erase(oldest);
-                }
-            }
-            if (limitCancelledUtteranceId != 0) {
-                FCITX_WARN() << "[voice-input:asr] Too many sessions, skip uid="
-                             << limitCancelledUtteranceId
-                             << " session=" << limitCancelledSessionId;
-                SkipUtterance(limitCancelledUtteranceId);
-            }
 
             const uint64_t utteranceId = ++utteranceCounter_;
             // Start new session
-            activeSession_ = engine->StartSession();
+            auto start = engine->StartSession();
+            if (start.cancelledSessionId) {
+                FCITX_WARN() << "[voice-input:asr] Too many sessions, skip "
+                             << "session=" << *start.cancelledSessionId;
+                results_->SkipSession(*start.cancelledSessionId);
+            }
+            activeSession_ = std::move(start.session);
             if (activeSession_) {
                 activeSessionId_ = activeSession_->GetState()->sessionId;
                 if (activeSession_->GetState()->finished) {
@@ -491,11 +291,10 @@ void Pipeline::AsrDispatcherLoop() {
                                  << activeSessionId_ << " already finished";
                     activeSession_.reset();
                     activeSessionId_ = 0;
-                    SkipUtterance(utteranceId);
+                    results_->SkipUtterance(utteranceId);
                 } else {
-                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                    sessionGenerationMap_[activeSessionId_] = {
-                        generation_.load(), utteranceId};
+                    results_->RegisterSession(
+                        activeSessionId_, {generation_.load(), utteranceId});
                     activeSession_->StartWorker();
                     FCITX_DEBUG() << "[voice-input:asr] Begin -> session="
                                  << activeSessionId_
@@ -504,7 +303,7 @@ void Pipeline::AsrDispatcherLoop() {
                 }
             } else {
                 FCITX_ERROR() << "[voice-input:asr] Begin failed: no ASR session";
-                SkipUtterance(utteranceId);
+                results_->SkipUtterance(utteranceId);
             }
             pendingAsrAudio_.clear();
             break;
@@ -544,24 +343,13 @@ void Pipeline::AsrDispatcherLoop() {
             break;
 
         case SpeechEventType::Cancel:
-            uint64_t cancelledUtteranceId = 0;
             if (activeSession_) {
-                {
-                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                    auto it = sessionGenerationMap_.find(activeSessionId_);
-                    if (it != sessionGenerationMap_.end()) {
-                        cancelledUtteranceId = it->second.utteranceId;
-                        sessionGenerationMap_.erase(it);
-                    }
-                }
+                results_->SkipSession(activeSessionId_);
                 activeSession_->Cancel();
                 FCITX_DEBUG() << "[voice-input:asr] Cancel -> session="
                              << activeSessionId_;
                 reaper_->Add(std::move(activeSession_));
                 activeSessionId_ = 0;
-            }
-            if (cancelledUtteranceId != 0) {
-                SkipUtterance(cancelledUtteranceId);
             }
             pendingAsrAudio_.clear();
             break;

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -76,27 +76,62 @@ void Pipeline::SetLLMClient(std::unique_ptr<LLMClient> client) {
     }
 }
 
+void Pipeline::SubmitOrderedResult(AsrResult result, bool terminal) {
+    std::string notificationText;
+    {
+        std::lock_guard<std::mutex> lock(orderedResultMutex_);
+        auto ready = orderedResults_.Submit(std::move(result), terminal);
+        if (ready.empty()) return;
+
+        notificationText = ready.back().text;
+        for (auto& item : ready) {
+            resultQueue_.Push(std::move(item));
+        }
+    }
+    if (resultCb_) {
+        resultCb_(notificationText);
+    }
+}
+
+void Pipeline::SkipUtterance(uint64_t utteranceId) {
+    std::string notificationText;
+    {
+        std::lock_guard<std::mutex> lock(orderedResultMutex_);
+        auto ready = orderedResults_.Skip(utteranceId);
+        if (ready.empty()) return;
+
+        notificationText = ready.back().text;
+        for (auto& item : ready) {
+            resultQueue_.Push(std::move(item));
+        }
+    }
+    if (resultCb_) {
+        resultCb_(notificationText);
+    }
+}
+
+void Pipeline::ResetOrderedResults() {
+    std::lock_guard<std::mutex> lock(orderedResultMutex_);
+    orderedResults_.Reset(utteranceCounter_.load() + 1);
+}
+
 void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
     std::shared_ptr<AsrEngine> enginePtr = std::move(engine);
-    if (!enginePtr) {
-        std::lock_guard<std::mutex> lock(engineMutex_);
-        asrEngine_ = nullptr;
-        return;
-    }
-    enginePtr->SetResultCallback(
-        [this, guard = resultGuard_](const std::string& text, bool isFinal,
-                                     uint64_t sid) {
+    if (enginePtr) {
+        enginePtr->SetResultCallback(
+            [this, guard = resultGuard_](const std::string& text, bool isFinal,
+                                         uint64_t sid) {
             // 会话 worker 线程可能晚于管线析构退出（reaper 超时 detach），
             // 回调前检查守卫，避免访问已析构的 Pipeline。
             if (!guard->load()) return;
 
             // Look up generation captured at session start
-            uint64_t gen = 0;
+            SessionMetadata metadata;
             {
                 std::lock_guard<std::mutex> lock(sessionMapMutex_);
                 auto it = sessionGenerationMap_.find(sid);
                 if (it == sessionGenerationMap_.end()) return;
-                gen = it->second;
+                metadata = it->second;
                 if (isFinal) {
                     sessionGenerationMap_.erase(sid);
                 }
@@ -105,106 +140,109 @@ void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
             if (isFinal) {
                 if (text.empty()) {
                     AsrResult errorResult;
-                    errorResult.generation = gen;
+                    errorResult.generation = metadata.generation;
                     errorResult.sessionId = sid;
+                    errorResult.utteranceId = metadata.utteranceId;
                     errorResult.isError = true;
-                    resultQueue_.Push(std::move(errorResult));
-                    if (resultCb_) resultCb_(text);
+                    SubmitOrderedResult(std::move(errorResult), true);
                     return;
-                }
-
-                uint64_t uid = ++utteranceCounter_;
-
-                AsrResult stale;
-                while (resultQueue_.TryPop(stale)) {
-                    if (stale.isLLMRefined) {
-                        FCITX_DEBUG() << "[voice-input] Drained stale LLM result: "
-                                     << "uid=" << stale.utteranceId;
-                    }
                 }
 
                 AsrResult rawResult;
                 rawResult.text = text;
-                rawResult.generation = gen;
+                rawResult.generation = metadata.generation;
                 rawResult.sessionId = sid;
-                rawResult.utteranceId = uid;
+                rawResult.utteranceId = metadata.utteranceId;
                 rawResult.isLLMRefined = false;
-                FCITX_DEBUG() << "[voice-input] ASR raw: uid=" << uid
+                FCITX_DEBUG() << "[voice-input] ASR raw: uid="
+                             << metadata.utteranceId
                              << " text=\"" << text << "\"";
-                resultQueue_.Push(std::move(rawResult));
-
-                if (resultCb_) {
-                    resultCb_(text);
-                }
+                SubmitOrderedResult(std::move(rawResult), !llmClient_);
 
                 if (llmClient_) {
                     FCITX_DEBUG() << "[voice-input] LLM refine started"
-                                 << " uid=" << uid << " gen=" << gen
+                                 << " uid=" << metadata.utteranceId
+                                 << " gen=" << metadata.generation
                                  << " stream=" << llmStream_;
                     if (llmStream_) {
-                        llmClient_->ProcessStream(text, gen,
-                            [this, guard, uid, gen,
+                        llmClient_->ProcessStream(text, metadata.generation,
+                            [this, guard, metadata,
                              sid](const std::string& partial) {
                                 if (!guard->load()) return;
                                 AsrResult partialResult;
                                 partialResult.text = partial;
-                                partialResult.generation = gen;
+                                partialResult.generation = metadata.generation;
                                 partialResult.sessionId = sid;
-                                partialResult.utteranceId = uid;
+                                partialResult.utteranceId = metadata.utteranceId;
                                 partialResult.isLLMRefined = true;
                                 partialResult.isPartial = true;
-                                resultQueue_.Push(std::move(partialResult));
-                                if (resultCb_) resultCb_(partial);
+                                SubmitOrderedResult(std::move(partialResult), false);
                             },
-                            [this, guard, uid, gen,
+                            [this, guard, metadata,
                              sid](const std::string& fullText) {
                                 if (!guard->load()) return;
                                 AsrResult finalResult;
                                 finalResult.text = fullText;
-                                finalResult.generation = gen;
+                                finalResult.generation = metadata.generation;
                                 finalResult.sessionId = sid;
-                                finalResult.utteranceId = uid;
+                                finalResult.utteranceId = metadata.utteranceId;
                                 finalResult.isLLMRefined = true;
                                 finalResult.isPartial = false;
-                                resultQueue_.Push(std::move(finalResult));
-                                if (resultCb_) resultCb_(fullText);
+                                SubmitOrderedResult(std::move(finalResult), true);
                             });
                     } else {
-                        llmClient_->Process(text, gen,
-                            [this, guard, uid, gen,
+                        llmClient_->Process(
+                            text, metadata.generation,
+                            [this, guard, metadata,
                              sid](const std::string& processed) {
                                 if (!guard->load()) return;
                                 AsrResult refinedResult;
                                 refinedResult.text = processed;
-                                refinedResult.generation = gen;
+                                refinedResult.generation = metadata.generation;
                                 refinedResult.sessionId = sid;
-                                refinedResult.utteranceId = uid;
+                                refinedResult.utteranceId = metadata.utteranceId;
                                 refinedResult.isLLMRefined = true;
-                                resultQueue_.Push(std::move(refinedResult));
-                                if (resultCb_) resultCb_(processed);
+                                SubmitOrderedResult(std::move(refinedResult), true);
                             });
                     }
                 }
             } else if (!text.empty()) {
                 AsrResult partial;
                 partial.text = text;
-                partial.generation = gen;
+                partial.generation = metadata.generation;
                 partial.sessionId = sid;
+                partial.utteranceId = metadata.utteranceId;
                 partial.isLLMRefined = false;
                 partial.isPartial = true;
-                resultQueue_.Push(std::move(partial));
-                if (resultCb_) resultCb_(text);
+                SubmitOrderedResult(std::move(partial), false);
             }
-        });
-    enginePtr->SetErrorCallback(
-        [this, guard = resultGuard_](const std::string& error) {
-            if (!guard->load()) return;
-            FCITX_ERROR() << "[voice-input] ASR error: " << error;
-        });
+            });
+        enginePtr->SetErrorCallback(
+            [this, guard = resultGuard_](const std::string& error) {
+                if (!guard->load()) return;
+                FCITX_ERROR() << "[voice-input] ASR error: " << error;
+            });
+    }
 
-    // 先绑定回调再发布指针，ASR 线程随后在锁内取用，避免使用到未绑定的引擎
-    std::lock_guard<std::mutex> lock(engineMutex_);
-    asrEngine_ = std::move(enginePtr);
+    std::shared_ptr<AsrEngine> previousEngine;
+    std::vector<uint64_t> skippedUtterances;
+    {
+        // 与 Begin 的锁顺序一致：先 engineMutex_，后 sessionMapMutex_。
+        std::lock_guard<std::mutex> engineLock(engineMutex_);
+        previousEngine = std::move(asrEngine_);
+        asrEngine_ = std::move(enginePtr);
+        std::lock_guard<std::mutex> sessionLock(sessionMapMutex_);
+        for (const auto& [sessionId, metadata] : sessionGenerationMap_) {
+            skippedUtterances.push_back(metadata.utteranceId);
+        }
+        sessionGenerationMap_.clear();
+    }
+    if (previousEngine) {
+        previousEngine->CancelAllSessions();
+    }
+    for (uint64_t utteranceId : skippedUtterances) {
+        SkipUtterance(utteranceId);
+    }
 }
 
 void Pipeline::SetResultCallback(ResultCallback cb) {
@@ -231,6 +269,7 @@ void Pipeline::Start() {
     // Drain stale results from previous session
     AsrResult stale;
     while (resultQueue_.TryPop(stale)) {}
+    ResetOrderedResults();
 
     vadWorker_->Start();
     if (!vadWorker_->IsRunning()) {
@@ -299,6 +338,7 @@ void Pipeline::Stop() {
         std::lock_guard<std::mutex> lock(sessionMapMutex_);
         sessionGenerationMap_.clear();
     }
+    ResetOrderedResults();
 
     FCITX_INFO() << "[voice-input] Pipeline stopped";
 }
@@ -343,6 +383,7 @@ void Pipeline::Abort() {
     while (speechEventQueue_.TryPop(se)) {}
     AsrResult r;
     while (resultQueue_.TryPop(r)) {}
+    ResetOrderedResults();
 
     // 终态：回调守卫失效，引擎 worker 线程的异步回调全部丢弃
     resultGuard_->store(false);
@@ -392,35 +433,78 @@ void Pipeline::AsrDispatcherLoop() {
 
         switch (ev.type) {
         case SpeechEventType::Begin: {
-            // 取引擎局部引用：SetAsrEngine 可能随时替换指针，持锁拷贝保证
-            // StartSession 期间引擎对象存活
-            std::shared_ptr<AsrEngine> engine;
-            {
-                std::lock_guard<std::mutex> lock(engineMutex_);
-                engine = asrEngine_;
-            }
+            // 持锁到 session 映射建立与 worker 启动完成，避免热更新丢失终态。
+            std::unique_lock<std::mutex> engineLock(engineMutex_);
+            std::shared_ptr<AsrEngine> engine = asrEngine_;
             if (!engine) break;
             // Cancel current session if still active
+            uint64_t cancelledUtteranceId = 0;
             if (activeSession_) {
                 {
                     std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                    sessionGenerationMap_.erase(activeSessionId_);
+                    auto it = sessionGenerationMap_.find(activeSessionId_);
+                    if (it != sessionGenerationMap_.end()) {
+                        cancelledUtteranceId = it->second.utteranceId;
+                        sessionGenerationMap_.erase(it);
+                    }
                 }
                 activeSession_->Cancel();
                 reaper_->Add(std::move(activeSession_));
                 activeSessionId_ = 0;
             }
+            if (cancelledUtteranceId != 0) {
+                SkipUtterance(cancelledUtteranceId);
+            }
+
+            uint64_t limitCancelledUtteranceId = 0;
+            uint64_t limitCancelledSessionId = 0;
+            {
+                std::lock_guard<std::mutex> lock(sessionMapMutex_);
+                if (sessionGenerationMap_.size() >=
+                    AsrEngine::kMaxActiveSessions) {
+                    auto oldest = sessionGenerationMap_.begin();
+                    for (auto it = sessionGenerationMap_.begin();
+                         it != sessionGenerationMap_.end(); ++it) {
+                        if (it->second.utteranceId < oldest->second.utteranceId) {
+                            oldest = it;
+                        }
+                    }
+                    limitCancelledSessionId = oldest->first;
+                    limitCancelledUtteranceId = oldest->second.utteranceId;
+                    sessionGenerationMap_.erase(oldest);
+                }
+            }
+            if (limitCancelledUtteranceId != 0) {
+                FCITX_WARN() << "[voice-input:asr] Too many sessions, skip uid="
+                             << limitCancelledUtteranceId
+                             << " session=" << limitCancelledSessionId;
+                SkipUtterance(limitCancelledUtteranceId);
+            }
+
+            const uint64_t utteranceId = ++utteranceCounter_;
             // Start new session
             activeSession_ = engine->StartSession();
             if (activeSession_) {
                 activeSessionId_ = activeSession_->GetState()->sessionId;
-                {
+                if (activeSession_->GetState()->finished) {
+                    FCITX_WARN() << "[voice-input:asr] Begin failed: session="
+                                 << activeSessionId_ << " already finished";
+                    activeSession_.reset();
+                    activeSessionId_ = 0;
+                    SkipUtterance(utteranceId);
+                } else {
                     std::lock_guard<std::mutex> lock(sessionMapMutex_);
-                    sessionGenerationMap_[activeSessionId_] = generation_.load();
+                    sessionGenerationMap_[activeSessionId_] = {
+                        generation_.load(), utteranceId};
+                    activeSession_->StartWorker();
+                    FCITX_DEBUG() << "[voice-input:asr] Begin -> session="
+                                 << activeSessionId_
+                                 << " uid=" << utteranceId
+                                 << " gen=" << generation_.load();
                 }
-                FCITX_DEBUG() << "[voice-input:asr] Begin -> session="
-                             << activeSessionId_
-                             << " gen=" << generation_.load();
+            } else {
+                FCITX_ERROR() << "[voice-input:asr] Begin failed: no ASR session";
+                SkipUtterance(utteranceId);
             }
             pendingAsrAudio_.clear();
             break;
@@ -460,12 +544,24 @@ void Pipeline::AsrDispatcherLoop() {
             break;
 
         case SpeechEventType::Cancel:
+            uint64_t cancelledUtteranceId = 0;
             if (activeSession_) {
+                {
+                    std::lock_guard<std::mutex> lock(sessionMapMutex_);
+                    auto it = sessionGenerationMap_.find(activeSessionId_);
+                    if (it != sessionGenerationMap_.end()) {
+                        cancelledUtteranceId = it->second.utteranceId;
+                        sessionGenerationMap_.erase(it);
+                    }
+                }
                 activeSession_->Cancel();
                 FCITX_DEBUG() << "[voice-input:asr] Cancel -> session="
                              << activeSessionId_;
                 reaper_->Add(std::move(activeSession_));
                 activeSessionId_ = 0;
+            }
+            if (cancelledUtteranceId != 0) {
+                SkipUtterance(cancelledUtteranceId);
             }
             pendingAsrAudio_.clear();
             break;

--- a/src/addon/pipeline/pipeline.h
+++ b/src/addon/pipeline/pipeline.h
@@ -16,6 +16,7 @@
 #include "asr/asr_session.h"
 #include "asr/session_reaper.h"
 #include "llm/llm_client.h"
+#include "pipeline/ordered_result_buffer.h"
 #include "types.h"
 #include "utils/thread_safe_queue.h"
 
@@ -49,8 +50,16 @@ public:
     void SetConfig(const VoiceInputConfig& config);
 
 private:
+    struct SessionMetadata {
+        uint64_t generation = 0;
+        uint64_t utteranceId = 0;
+    };
+
     bool StartCapture();
     void AsrDispatcherLoop();
+    void SubmitOrderedResult(AsrResult result, bool terminal);
+    void SkipUtterance(uint64_t utteranceId);
+    void ResetOrderedResults();
 
     // Queues（带容量上限：超限丢最旧，防止异常路径下内存无界增长）
     // 1024 帧 ≈ 32s 音频缓冲；256 事件 ≈ 256 段语音；128 结果
@@ -69,7 +78,7 @@ private:
     std::shared_ptr<AsrEngine> asrEngine_;
     std::shared_ptr<AsrSession> activeSession_;
     uint64_t activeSessionId_{0};
-    std::unordered_map<uint64_t, uint64_t> sessionGenerationMap_;
+    std::unordered_map<uint64_t, SessionMetadata> sessionGenerationMap_;
     std::mutex sessionMapMutex_;   // 保护 sessionGenerationMap_（worker/ASR/主线程三方）
     std::mutex engineMutex_;       // 保护 asrEngine_ 指针替换与使用
     std::unique_ptr<SessionReaper> reaper_;
@@ -85,6 +94,8 @@ private:
     std::atomic<bool> running_{false};
     std::atomic<uint64_t> generation_{0};
     std::atomic<uint64_t> utteranceCounter_{0};
+    OrderedResultBuffer orderedResults_;
+    std::mutex orderedResultMutex_;
     // 回调守卫：Abort 后置 false，引擎 worker 线程的异步回调据此丢弃
     std::shared_ptr<std::atomic<bool>> resultGuard_ =
         std::make_shared<std::atomic<bool>>(true);

--- a/src/addon/pipeline/pipeline.h
+++ b/src/addon/pipeline/pipeline.h
@@ -6,7 +6,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include "config/voiceinput-config.h"
@@ -15,8 +14,7 @@
 #include "asr/asr_engine.h"
 #include "asr/asr_session.h"
 #include "asr/session_reaper.h"
-#include "llm/llm_client.h"
-#include "pipeline/ordered_result_buffer.h"
+#include "pipeline/result_coordinator.h"
 #include "types.h"
 #include "utils/thread_safe_queue.h"
 
@@ -35,7 +33,7 @@ public:
     void Init(const VoiceInputConfig& config);
     void SetAsrEngine(std::unique_ptr<AsrEngine> engine);
     void SetLLMClient(std::unique_ptr<LLMClient> client);
-    void SetLLMStream(bool stream) { llmStream_ = stream; }
+    void SetLLMStream(bool stream) { results_->SetLLMStream(stream); }
     void SetResultCallback(ResultCallback cb);
     void SetVadStatusCallback(VADWorker::VadStatusCallback cb);
     void SetGeneration(uint64_t gen) { generation_.store(gen); }
@@ -45,27 +43,20 @@ public:
     void Abort();
     bool IsRunning() const { return running_.load(); }
 
-    ThreadSafeQueue<AsrResult>& ResultQueue() { return resultQueue_; }
+    ThreadSafeQueue<AsrResult>& ResultQueue() {
+        return results_->ResultQueue();
+    }
 
     void SetConfig(const VoiceInputConfig& config);
 
 private:
-    struct SessionMetadata {
-        uint64_t generation = 0;
-        uint64_t utteranceId = 0;
-    };
-
     bool StartCapture();
     void AsrDispatcherLoop();
-    void SubmitOrderedResult(AsrResult result, bool terminal);
-    void SkipUtterance(uint64_t utteranceId);
-    void ResetOrderedResults();
 
-    // Queues（带容量上限：超限丢最旧，防止异常路径下内存无界增长）
-    // 1024 帧 ≈ 32s 音频缓冲；256 事件 ≈ 256 段语音；128 结果
+    // 音频与语音事件可丢旧；识别终态由 ResultCoordinator 无损保存。
+    // 1024 帧 ≈ 32s 音频缓冲；256 事件 ≈ 256 段语音。
     ThreadSafeQueue<AudioFrame> frameQueue_{1024};
     ThreadSafeQueue<SpeechEvent> speechEventQueue_{256};
-    ThreadSafeQueue<AsrResult> resultQueue_{128};
 
     // Workers
     std::unique_ptr<VADWorker> vadWorker_;
@@ -78,33 +69,20 @@ private:
     std::shared_ptr<AsrEngine> asrEngine_;
     std::shared_ptr<AsrSession> activeSession_;
     uint64_t activeSessionId_{0};
-    std::unordered_map<uint64_t, SessionMetadata> sessionGenerationMap_;
-    std::mutex sessionMapMutex_;   // 保护 sessionGenerationMap_（worker/ASR/主线程三方）
     std::mutex engineMutex_;       // 保护 asrEngine_ 指针替换与使用
     std::unique_ptr<SessionReaper> reaper_;
 
     // ASR streaming batching
     std::vector<float> pendingAsrAudio_;
 
-    // LLM
-    std::unique_ptr<LLMClient> llmClient_;
-    bool llmStream_ = true;
-
     // State
     std::atomic<bool> running_{false};
     std::atomic<uint64_t> generation_{0};
     std::atomic<uint64_t> utteranceCounter_{0};
-    OrderedResultBuffer orderedResults_;
-    std::mutex orderedResultMutex_;
-    // 回调守卫：Abort 后置 false，引擎 worker 线程的异步回调据此丢弃
-    std::shared_ptr<std::atomic<bool>> resultGuard_ =
-        std::make_shared<std::atomic<bool>>(true);
+    std::shared_ptr<ResultCoordinator> results_;
 
     // Config
     VoiceInputConfig config_;
-
-    // Callback
-    ResultCallback resultCb_;
 };
 
 } // namespace fcitx

--- a/src/addon/pipeline/result_coordinator.cpp
+++ b/src/addon/pipeline/result_coordinator.cpp
@@ -1,0 +1,286 @@
+#include "result_coordinator.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace fcitx {
+namespace {
+
+AsrResult MakeResult(const std::string& text, uint64_t sessionId,
+                     const ResultCoordinator::SessionMetadata& metadata) {
+    AsrResult result;
+    result.text = text;
+    result.generation = metadata.generation;
+    result.sessionId = sessionId;
+    result.utteranceId = metadata.utteranceId;
+    return result;
+}
+
+} // namespace
+
+void ResultCoordinator::Start(uint64_t firstUtteranceId,
+                              uint64_t generation) {
+    std::shared_ptr<LLMClient> client;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (closed_) return;
+        accepting_ = true;
+        generation_ = generation;
+        sessions_.clear();
+        orderedResults_.Reset(firstUtteranceId);
+        resultQueue_.Clear();
+        client = llmClient_;
+    }
+    if (client) client->Activate(generation);
+}
+
+std::shared_ptr<LLMClient> ResultCoordinator::DeactivateLocked(
+    uint64_t nextUtteranceId, bool permanently) {
+    accepting_ = false;
+    closed_ = closed_ || permanently;
+    sessions_.clear();
+    orderedResults_.Reset(nextUtteranceId);
+    resultQueue_.Clear();
+    return llmClient_;
+}
+
+void ResultCoordinator::Pause(uint64_t nextUtteranceId) {
+    std::shared_ptr<LLMClient> client;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        client = DeactivateLocked(nextUtteranceId, false);
+    }
+    if (client) client->Cancel();
+}
+
+void ResultCoordinator::Close(uint64_t nextUtteranceId) {
+    std::shared_ptr<LLMClient> client;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        client = DeactivateLocked(nextUtteranceId, true);
+    }
+    if (client) client->Cancel();
+    CloseNotifications();
+}
+
+void ResultCoordinator::SetResultCallback(ResultCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    if (callbacksOpen_) resultCallback_ = std::move(callback);
+}
+
+void ResultCoordinator::SetLLMClient(std::shared_ptr<LLMClient> client) {
+    std::shared_ptr<LLMClient> previous;
+    uint64_t generation = 0;
+    bool activate = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        previous = std::exchange(llmClient_, client);
+        generation = generation_;
+        activate = accepting_ && !closed_;
+    }
+    if (previous) previous->Cancel();
+    if (client && activate) client->Activate(generation);
+}
+
+void ResultCoordinator::SetLLMStream(bool stream) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    llmStream_ = stream;
+}
+
+void ResultCoordinator::RegisterSession(uint64_t sessionId,
+                                        SessionMetadata metadata) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (accepting_ && metadata.generation == generation_) {
+        sessions_[sessionId] = metadata;
+    }
+}
+
+std::optional<ResultCoordinator::ResultContext>
+ResultCoordinator::TakeContext(uint64_t sessionId, bool isFinal) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!accepting_) return std::nullopt;
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) return std::nullopt;
+
+    ResultContext context{it->second, llmClient_, llmStream_};
+    if (isFinal) sessions_.erase(it);
+    return context;
+}
+
+void ResultCoordinator::HandleAsrResult(const std::string& text, bool isFinal,
+                                        uint64_t sessionId) {
+    auto context = TakeContext(sessionId, isFinal);
+    if (!context) return;
+
+    if (isFinal) {
+        HandleFinal(text, sessionId, *context);
+    } else if (!text.empty()) {
+        auto partial = MakeResult(text, sessionId, context->metadata);
+        partial.isPartial = true;
+        Submit(std::move(partial), false);
+    }
+}
+
+void ResultCoordinator::HandleFinal(const std::string& text,
+                                    uint64_t sessionId,
+                                    const ResultContext& context) {
+    if (text.empty()) {
+        auto error = MakeResult({}, sessionId, context.metadata);
+        error.isError = true;
+        Submit(std::move(error), true);
+        return;
+    }
+
+    auto raw = MakeResult(text, sessionId, context.metadata);
+    Submit(std::move(raw), !context.llmClient);
+    if (context.llmClient) Refine(text, sessionId, context);
+}
+
+void ResultCoordinator::Refine(const std::string& text, uint64_t sessionId,
+                               const ResultContext& context) {
+    if (context.llmStream) {
+        RefineStream(text, sessionId, context);
+        return;
+    }
+
+    bool completed = false;
+    auto self = shared_from_this();
+    context.llmClient->Process(
+        text, context.metadata.generation,
+        [self, &completed, sessionId,
+         metadata = context.metadata](const std::string& processed) {
+            completed = true;
+            auto result = MakeResult(processed, sessionId, metadata);
+            result.isLLMRefined = true;
+            self->Submit(std::move(result), true);
+        });
+    if (!completed) {
+        auto fallback = MakeResult(text, sessionId, context.metadata);
+        fallback.isLLMRefined = true;
+        Submit(std::move(fallback), true);
+    }
+}
+
+void ResultCoordinator::RefineStream(const std::string& text,
+                                     uint64_t sessionId,
+                                     const ResultContext& context) {
+    bool completed = false;
+    auto self = shared_from_this();
+    context.llmClient->ProcessStream(
+        text, context.metadata.generation,
+        [self, sessionId,
+         metadata = context.metadata](const std::string& partialText) {
+            auto partial = MakeResult(partialText, sessionId, metadata);
+            partial.isLLMRefined = true;
+            partial.isPartial = true;
+            self->Submit(std::move(partial), false);
+        },
+        [self, &completed, sessionId,
+         metadata = context.metadata](const std::string& finalText) {
+            completed = true;
+            auto result = MakeResult(finalText, sessionId, metadata);
+            result.isLLMRefined = true;
+            self->Submit(std::move(result), true);
+        });
+    if (!completed) {
+        auto fallback = MakeResult(text, sessionId, context.metadata);
+        fallback.isLLMRefined = true;
+        Submit(std::move(fallback), true);
+    }
+}
+
+std::optional<std::string> ResultCoordinator::EnqueueLocked(
+    std::vector<AsrResult> ready) {
+    if (ready.empty()) return std::nullopt;
+    std::string notification = ready.back().text;
+    for (auto& result : ready) resultQueue_.Push(std::move(result));
+    return notification;
+}
+
+void ResultCoordinator::Submit(AsrResult result, bool terminal) {
+    std::optional<std::string> notification;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!accepting_ || result.generation != generation_) return;
+        notification = EnqueueLocked(
+            orderedResults_.Submit(std::move(result), terminal));
+    }
+    if (notification) Notify(*notification);
+}
+
+void ResultCoordinator::SkipSession(uint64_t sessionId) {
+    std::optional<std::string> notification;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = sessions_.find(sessionId);
+        if (!accepting_ || it == sessions_.end()) return;
+        const uint64_t utteranceId = it->second.utteranceId;
+        sessions_.erase(it);
+        notification = EnqueueLocked(orderedResults_.Skip(utteranceId));
+    }
+    if (notification) Notify(*notification);
+}
+
+void ResultCoordinator::SkipUtterance(uint64_t utteranceId) {
+    std::optional<std::string> notification;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!accepting_) return;
+        notification = EnqueueLocked(orderedResults_.Skip(utteranceId));
+    }
+    if (notification) Notify(*notification);
+}
+
+void ResultCoordinator::SkipAllSessions() {
+    std::optional<std::string> notification;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!accepting_) return;
+        std::vector<uint64_t> utteranceIds;
+        utteranceIds.reserve(sessions_.size());
+        for (const auto& [sessionId, metadata] : sessions_) {
+            utteranceIds.push_back(metadata.utteranceId);
+        }
+        sessions_.clear();
+        std::sort(utteranceIds.begin(), utteranceIds.end());
+        for (uint64_t utteranceId : utteranceIds) {
+            auto ready = orderedResults_.Skip(utteranceId);
+            if (auto latest = EnqueueLocked(std::move(ready))) {
+                notification = std::move(latest);
+            }
+        }
+    }
+    if (notification) Notify(*notification);
+}
+
+void ResultCoordinator::Notify(const std::string& text) {
+    ResultCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(callbackMutex_);
+        if (!callbacksOpen_ || !resultCallback_) return;
+        callback = resultCallback_;
+        ++callbacksInFlight_;
+    }
+    try {
+        callback(text);
+    } catch (...) {
+        FinishNotification();
+        throw;
+    }
+    FinishNotification();
+}
+
+void ResultCoordinator::FinishNotification() {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    --callbacksInFlight_;
+    if (!callbacksOpen_ && callbacksInFlight_ == 0) callbackCv_.notify_all();
+}
+
+void ResultCoordinator::CloseNotifications() {
+    std::unique_lock<std::mutex> lock(callbackMutex_);
+    callbacksOpen_ = false;
+    resultCallback_ = {};
+    callbackCv_.wait(lock, [this] { return callbacksInFlight_ == 0; });
+}
+
+} // namespace fcitx

--- a/src/addon/pipeline/result_coordinator.h
+++ b/src/addon/pipeline/result_coordinator.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "llm/llm_client.h"
+#include "pipeline/ordered_result_buffer.h"
+#include "types.h"
+#include "utils/thread_safe_queue.h"
+
+namespace fcitx {
+
+// 管理异步 ASR/LLM 回调的完整共享状态，允许其安全晚于 Pipeline 退出。
+class ResultCoordinator final
+    : public std::enable_shared_from_this<ResultCoordinator> {
+public:
+    using ResultCallback = std::function<void(const std::string& text)>;
+
+    struct SessionMetadata {
+        uint64_t generation = 0;
+        uint64_t utteranceId = 0;
+    };
+
+    void Start(uint64_t firstUtteranceId, uint64_t generation);
+    void Pause(uint64_t nextUtteranceId);
+    void Close(uint64_t nextUtteranceId);
+
+    // 回调必须短小，且不得递归调用 Close()。
+    void SetResultCallback(ResultCallback callback);
+    void SetLLMClient(std::shared_ptr<LLMClient> client);
+    void SetLLMStream(bool stream);
+
+    void RegisterSession(uint64_t sessionId, SessionMetadata metadata);
+    void SkipSession(uint64_t sessionId);
+    void SkipUtterance(uint64_t utteranceId);
+    void SkipAllSessions();
+    void HandleAsrResult(const std::string& text, bool isFinal,
+                         uint64_t sessionId);
+
+    ThreadSafeQueue<AsrResult>& ResultQueue() { return resultQueue_; }
+
+private:
+    struct ResultContext {
+        SessionMetadata metadata;
+        std::shared_ptr<LLMClient> llmClient;
+        bool llmStream = true;
+    };
+
+    std::optional<ResultContext> TakeContext(uint64_t sessionId, bool isFinal);
+    void HandleFinal(const std::string& text, uint64_t sessionId,
+                     const ResultContext& context);
+    void Refine(const std::string& text, uint64_t sessionId,
+                const ResultContext& context);
+    void RefineStream(const std::string& text, uint64_t sessionId,
+                      const ResultContext& context);
+    void Submit(AsrResult result, bool terminal);
+    std::optional<std::string> EnqueueLocked(std::vector<AsrResult> ready);
+    std::shared_ptr<LLMClient> DeactivateLocked(uint64_t nextUtteranceId,
+                                                bool permanently);
+
+    void Notify(const std::string& text);
+    void FinishNotification();
+    void CloseNotifications();
+
+    std::mutex mutex_;
+    bool accepting_ = false;
+    bool closed_ = false;
+    uint64_t generation_ = 0;
+    std::unordered_map<uint64_t, SessionMetadata> sessions_;
+    OrderedResultBuffer orderedResults_;
+    ThreadSafeQueue<AsrResult> resultQueue_;
+    std::shared_ptr<LLMClient> llmClient_;
+    bool llmStream_ = true;
+
+    std::mutex callbackMutex_;
+    std::condition_variable callbackCv_;
+    ResultCallback resultCallback_;
+    bool callbacksOpen_ = true;
+    size_t callbacksInFlight_ = 0;
+};
+
+} // namespace fcitx

--- a/src/addon/vad/vad.cpp
+++ b/src/addon/vad/vad.cpp
@@ -128,8 +128,6 @@ void VADWorker::ProcessFrame(const AudioFrame& frame, float probability,
     bool speechStart = probability >= config.speechThreshold;
     bool speechKeep = probability >= config.silenceThreshold;
 
-    AppendPreRoll(frame.pcm, PreRollSamples(config.preRollMs));
-
     if (state_ == State::Idle) {
         if (speechStart) {
             speechFrames_++;
@@ -169,6 +167,9 @@ void VADWorker::ProcessFrame(const AudioFrame& frame, float probability,
             }
         } else {
             speechFrames_ = 0;
+        }
+        if (state_ == State::Idle) {
+            AppendPreRoll(frame.pcm, PreRollSamples(config.preRollMs));
         }
         return;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,3 +52,36 @@ target_include_directories(asr_ordering_test PRIVATE
 )
 
 add_test(NAME asr_ordering_test COMMAND asr_ordering_test)
+
+add_executable(result_coordinator_test
+    result_coordinator_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/addon/pipeline/result_coordinator.cpp
+    ${CMAKE_SOURCE_DIR}/src/addon/llm/llm_client.cpp
+)
+
+target_include_directories(result_coordinator_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+    ${FCITX5_INCLUDE_DIRS}
+    ${JSONCPP_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
+)
+
+target_link_libraries(result_coordinator_test PRIVATE
+    ${FCITX5_LIBRARIES}
+    ${JSONCPP_LIBRARIES}
+    CURL::libcurl
+)
+
+add_test(NAME result_coordinator_test COMMAND result_coordinator_test)
+
+add_executable(realtime_terminal_state_test
+    realtime_terminal_state_test.cpp
+)
+
+target_include_directories(realtime_terminal_state_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+)
+
+add_test(NAME realtime_terminal_state_test
+    COMMAND realtime_terminal_state_test
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,3 +41,14 @@ target_link_libraries(llm_request_cancellation_test PRIVATE
 add_test(NAME llm_request_cancellation_test
     COMMAND llm_request_cancellation_test
 )
+
+add_executable(asr_ordering_test
+    asr_ordering_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/addon/asr/asr_engine.cpp
+)
+
+target_include_directories(asr_ordering_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+)
+
+add_test(NAME asr_ordering_test COMMAND asr_ordering_test)

--- a/tests/asr_ordering_test.cpp
+++ b/tests/asr_ordering_test.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "asr/asr_engine.h"
 #include "pipeline/ordered_result_buffer.h"
@@ -11,6 +12,7 @@ namespace {
 using fcitx::AsrEngine;
 using fcitx::AsrResult;
 using fcitx::AsrSession;
+using fcitx::AsrSessionStart;
 using fcitx::OrderedResultBuffer;
 
 bool Check(bool condition, const std::string& message) {
@@ -36,26 +38,24 @@ public:
 class TestEngine final : public AsrEngine {
 public:
     bool Init(const Config&) override { return true; }
-    std::shared_ptr<AsrSession> StartSession() override { return {}; }
-    const char* Name() const override { return "test"; }
-
-    std::shared_ptr<TestSession> AddSession() {
+    AsrSessionStart StartSession() override {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
+        auto cancelled = CancelOldestSessionIfLimitReachedLocked();
         const auto sessionId = nextSessionId_++;
         auto session = std::make_shared<TestSession>(sessionId);
         sessions_[sessionId] = session;
-        return session;
+        retainedSessions_.push_back(session);
+        return {session, cancelled};
     }
-
-    uint64_t CancelOldestAtLimit() {
-        std::lock_guard<std::mutex> lock(sessionsMutex_);
-        return CancelOldestSessionIfLimitReachedLocked().value_or(0);
-    }
+    const char* Name() const override { return "test"; }
 
     size_t SessionCount() {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         return sessions_.size();
     }
+
+private:
+    std::vector<std::shared_ptr<TestSession>> retainedSessions_;
 };
 
 AsrResult Result(uint64_t utteranceId, std::string text) {
@@ -109,19 +109,66 @@ bool TestSkippedUtteranceUnblocksLaterResult() {
            Check(ready[0].text == "B", "B must be released after A is skipped");
 }
 
+bool TestSkipDiscardsCachedAndLateResults() {
+    OrderedResultBuffer buffer;
+    buffer.Reset(1);
+
+    auto ready = buffer.Submit(Result(2, "B cached partial"), false);
+    if (!Check(ready.empty(), "B partial must wait for A")) return false;
+
+    ready = buffer.Skip(2);
+    if (!Check(ready.empty(), "skipping future B must still wait for A")) {
+        return false;
+    }
+
+    ready = buffer.Submit(Result(2, "B late final"), true);
+    if (!Check(ready.empty(), "late B result must be discarded")) return false;
+
+    ready = buffer.Submit(Result(1, "A"), true);
+    return Check(ready.size() == 1,
+                 "skipped B must not release cached or late results") &&
+           Check(ready[0].text == "A", "only A may be released");
+}
+
 bool TestSessionLimitCancelsOldestSession() {
     TestEngine engine;
-    auto first = engine.AddSession();
-    auto second = engine.AddSession();
-    auto third = engine.AddSession();
+    auto first = engine.StartSession();
+    engine.StartSession();
+    engine.StartSession();
+    auto fourth = engine.StartSession();
 
-    const auto cancelledId = engine.CancelOldestAtLimit();
-    return Check(cancelledId == first->GetState()->sessionId,
+    return Check(fourth.cancelledSessionId ==
+                     first.session->GetState()->sessionId,
                  "the oldest session must be cancelled") &&
-           Check(first->GetState()->cancelled,
+           Check(first.session->GetState()->cancelled,
                  "the oldest session must receive Cancel") &&
-           Check(engine.SessionCount() == 2,
-                 "the cancelled session must be removed before adding another");
+           Check(engine.SessionCount() == AsrEngine::kMaxActiveSessions,
+                 "the engine must retain exactly the configured limit");
+}
+
+bool TestReportedCancellationUnblocksCompletedMiddleSession() {
+    TestEngine engine;
+    auto first = engine.StartSession();
+    engine.StartSession();
+    engine.StartSession();
+
+    OrderedResultBuffer buffer;
+    buffer.Reset(1);
+    buffer.Submit(Result(2, "B"), true);
+    buffer.Submit(Result(3, "C"), true);
+
+    auto fourth = engine.StartSession();
+    if (!Check(fourth.cancelledSessionId ==
+                   first.session->GetState()->sessionId,
+               "StartSession must report the session it actually cancelled")) {
+        return false;
+    }
+
+    auto ready = buffer.Skip(1);
+    return Check(ready.size() == 2,
+                 "skipping the reported oldest session must release B and C") &&
+           Check(ready[0].text == "B" && ready[1].text == "C",
+                 "completed middle sessions must retain their order");
 }
 
 } // namespace
@@ -130,7 +177,9 @@ int main() {
     return TestResultsAreReleasedInSpeechOrder() &&
                    TestLlmResultBlocksLaterUtteranceUntilFinal() &&
                    TestSkippedUtteranceUnblocksLaterResult() &&
-                   TestSessionLimitCancelsOldestSession()
+                   TestSkipDiscardsCachedAndLateResults() &&
+                   TestSessionLimitCancelsOldestSession() &&
+                   TestReportedCancellationUnblocksCompletedMiddleSession()
                ? 0
                : 1;
 }

--- a/tests/asr_ordering_test.cpp
+++ b/tests/asr_ordering_test.cpp
@@ -1,0 +1,136 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "asr/asr_engine.h"
+#include "pipeline/ordered_result_buffer.h"
+
+namespace {
+
+using fcitx::AsrEngine;
+using fcitx::AsrResult;
+using fcitx::AsrSession;
+using fcitx::OrderedResultBuffer;
+
+bool Check(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+class TestSession final : public AsrSession {
+public:
+    explicit TestSession(uint64_t sessionId) {
+        state_->sessionId = sessionId;
+    }
+
+    void FeedAudio(const float*, size_t) override {}
+    void End() override {}
+    void Cancel() override { state_->cancelled = true; }
+    void JoinWithTimeout(std::chrono::milliseconds) override {}
+    void StartWorker() override {}
+};
+
+class TestEngine final : public AsrEngine {
+public:
+    bool Init(const Config&) override { return true; }
+    std::shared_ptr<AsrSession> StartSession() override { return {}; }
+    const char* Name() const override { return "test"; }
+
+    std::shared_ptr<TestSession> AddSession() {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        const auto sessionId = nextSessionId_++;
+        auto session = std::make_shared<TestSession>(sessionId);
+        sessions_[sessionId] = session;
+        return session;
+    }
+
+    uint64_t CancelOldestAtLimit() {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        return CancelOldestSessionIfLimitReachedLocked().value_or(0);
+    }
+
+    size_t SessionCount() {
+        std::lock_guard<std::mutex> lock(sessionsMutex_);
+        return sessions_.size();
+    }
+};
+
+AsrResult Result(uint64_t utteranceId, std::string text) {
+    AsrResult result;
+    result.utteranceId = utteranceId;
+    result.text = std::move(text);
+    return result;
+}
+
+bool TestResultsAreReleasedInSpeechOrder() {
+    OrderedResultBuffer buffer;
+    buffer.Reset(1);
+
+    auto ready = buffer.Submit(Result(2, "B"), true);
+    if (!Check(ready.empty(), "B must wait for A")) return false;
+
+    ready = buffer.Submit(Result(1, "A"), true);
+    return Check(ready.size() == 2, "A and B must both be released") &&
+           Check(ready[0].text == "A", "A must be released first") &&
+           Check(ready[1].text == "B", "B must be released second");
+}
+
+bool TestLlmResultBlocksLaterUtteranceUntilFinal() {
+    OrderedResultBuffer buffer;
+    buffer.Reset(1);
+
+    auto ready = buffer.Submit(Result(1, "A raw"), false);
+    if (!Check(ready.size() == 1 && ready[0].text == "A raw",
+               "raw A result must be visible")) {
+        return false;
+    }
+
+    ready = buffer.Submit(Result(2, "B"), true);
+    if (!Check(ready.empty(), "B must wait for A LLM final")) return false;
+
+    ready = buffer.Submit(Result(1, "A refined"), true);
+    return Check(ready.size() == 2, "A refined and B must be released") &&
+           Check(ready[0].text == "A refined", "A refined must precede B") &&
+           Check(ready[1].text == "B", "B must follow A refined");
+}
+
+bool TestSkippedUtteranceUnblocksLaterResult() {
+    OrderedResultBuffer buffer;
+    buffer.Reset(1);
+
+    auto ready = buffer.Submit(Result(2, "B"), true);
+    if (!Check(ready.empty(), "B must wait until A is resolved")) return false;
+
+    ready = buffer.Skip(1);
+    return Check(ready.size() == 1, "skipping A must release B") &&
+           Check(ready[0].text == "B", "B must be released after A is skipped");
+}
+
+bool TestSessionLimitCancelsOldestSession() {
+    TestEngine engine;
+    auto first = engine.AddSession();
+    auto second = engine.AddSession();
+    auto third = engine.AddSession();
+
+    const auto cancelledId = engine.CancelOldestAtLimit();
+    return Check(cancelledId == first->GetState()->sessionId,
+                 "the oldest session must be cancelled") &&
+           Check(first->GetState()->cancelled,
+                 "the oldest session must receive Cancel") &&
+           Check(engine.SessionCount() == 2,
+                 "the cancelled session must be removed before adding another");
+}
+
+} // namespace
+
+int main() {
+    return TestResultsAreReleasedInSpeechOrder() &&
+                   TestLlmResultBlocksLaterUtteranceUntilFinal() &&
+                   TestSkippedUtteranceUnblocksLaterResult() &&
+                   TestSessionLimitCancelsOldestSession()
+               ? 0
+               : 1;
+}

--- a/tests/asr_ordering_test.cpp
+++ b/tests/asr_ordering_test.cpp
@@ -41,7 +41,7 @@ public:
     AsrSessionStart StartSession() override {
         std::lock_guard<std::mutex> lock(sessionsMutex_);
         auto cancelled = CancelOldestSessionIfLimitReachedLocked();
-        const auto sessionId = nextSessionId_++;
+        const auto sessionId = NextSessionId();
         auto session = std::make_shared<TestSession>(sessionId);
         sessions_[sessionId] = session;
         retainedSessions_.push_back(session);
@@ -171,6 +171,17 @@ bool TestReportedCancellationUnblocksCompletedMiddleSession() {
                  "completed middle sessions must retain their order");
 }
 
+bool TestSessionIdsAreUniqueAcrossEngines() {
+    TestEngine firstEngine;
+    TestEngine replacementEngine;
+    auto oldSession = firstEngine.StartSession();
+    auto newSession = replacementEngine.StartSession();
+
+    return Check(oldSession.session->GetState()->sessionId !=
+                     newSession.session->GetState()->sessionId,
+                 "replacement engines must not reuse session IDs");
+}
+
 } // namespace
 
 int main() {
@@ -179,7 +190,8 @@ int main() {
                    TestSkippedUtteranceUnblocksLaterResult() &&
                    TestSkipDiscardsCachedAndLateResults() &&
                    TestSessionLimitCancelsOldestSession() &&
-                   TestReportedCancellationUnblocksCompletedMiddleSession()
+                   TestReportedCancellationUnblocksCompletedMiddleSession() &&
+                   TestSessionIdsAreUniqueAcrossEngines()
                ? 0
                : 1;
 }

--- a/tests/realtime_terminal_state_test.cpp
+++ b/tests/realtime_terminal_state_test.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+
+#include "asr/realtime_asr.h"
+
+namespace {
+
+bool Check(bool condition, const char* message) {
+    if (!condition) std::cerr << message << '\n';
+    return condition;
+}
+
+bool TestTransportFailureIsNotFinal() {
+    using fcitx::DecideRealtimeServerOutcome;
+    using fcitx::RealtimeServerOutcome;
+
+    const auto beforeEnd = DecideRealtimeServerOutcome(
+        RealtimeServerOutcome::TransportFailure, false);
+    const auto afterEnd = DecideRealtimeServerOutcome(
+        RealtimeServerOutcome::TransportFailure, true);
+    return Check(beforeEnd.reconnect && !beforeEnd.publishFallback,
+                 "transport failure before End must reconnect") &&
+           Check(afterEnd.stop && afterEnd.publishFallback,
+                 "transport failure after End must publish a fallback final");
+}
+
+bool TestFinalOutcomeStopsWithoutFallback() {
+    const auto decision = fcitx::DecideRealtimeServerOutcome(
+        fcitx::RealtimeServerOutcome::FinalReceived, true);
+    return Check(decision.stop, "a real final must stop receiving") &&
+           Check(!decision.reconnect, "a real final must not reconnect") &&
+           Check(!decision.publishFallback,
+                 "a real final must not emit a duplicate fallback");
+}
+
+bool TestTerminalCanOnlyBePublishedOnce() {
+    fcitx::RealtimeTerminalState terminal;
+    return Check(terminal.TryMarkPublished(),
+                 "the first terminal publication must be accepted") &&
+           Check(!terminal.TryMarkPublished(),
+                 "a duplicate terminal publication must be rejected") &&
+           Check(terminal.IsPublished(), "terminal state must remain published");
+}
+
+} // namespace
+
+int main() {
+    return TestTransportFailureIsNotFinal() &&
+                   TestFinalOutcomeStopsWithoutFallback() &&
+                   TestTerminalCanOnlyBePublishedOnce()
+               ? 0
+               : 1;
+}

--- a/tests/result_coordinator_test.cpp
+++ b/tests/result_coordinator_test.cpp
@@ -1,0 +1,151 @@
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "pipeline/result_coordinator.h"
+
+namespace {
+
+using namespace std::chrono_literals;
+using fcitx::AsrResult;
+using fcitx::ResultCoordinator;
+
+bool Check(bool condition, const char* message) {
+    if (!condition) std::cerr << message << '\n';
+    return condition;
+}
+
+void Register(ResultCoordinator& coordinator, uint64_t id) {
+    coordinator.RegisterSession(id, {1, id});
+}
+
+bool TestMoreThan128TerminalResultsAreRetained() {
+    auto coordinator = std::make_shared<ResultCoordinator>();
+    coordinator->Start(1, 1);
+    for (uint64_t id = 1; id <= 130; ++id) Register(*coordinator, id);
+
+    for (uint64_t id = 130; id > 0; --id) {
+        coordinator->HandleAsrResult(std::to_string(id), true, id);
+    }
+
+    if (!Check(coordinator->ResultQueue().Size() == 130,
+               "terminal results must not be dropped at the old queue limit")) {
+        return false;
+    }
+
+    AsrResult result;
+    for (uint64_t id = 1; id <= 130; ++id) {
+        if (!Check(coordinator->ResultQueue().TryPop(result),
+                   "every terminal result must remain available") ||
+            !Check(result.utteranceId == id,
+                   "terminal results must retain utterance order")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool TestSkippedSessionRejectsLateCallback() {
+    auto coordinator = std::make_shared<ResultCoordinator>();
+    coordinator->Start(1, 1);
+    Register(*coordinator, 1);
+    Register(*coordinator, 2);
+
+    coordinator->HandleAsrResult("B partial", false, 2);
+    coordinator->SkipSession(2);
+    coordinator->HandleAsrResult("B late", true, 2);
+    coordinator->HandleAsrResult("A", true, 1);
+
+    AsrResult result;
+    return Check(coordinator->ResultQueue().TryPop(result),
+                 "A terminal result must be delivered") &&
+           Check(result.text == "A", "only A may be delivered") &&
+           Check(!coordinator->ResultQueue().TryPop(result),
+                 "skipped B callbacks must be discarded");
+}
+
+bool TestLlmWithoutCompletionFallsBackToTerminalRawText() {
+    auto coordinator = std::make_shared<ResultCoordinator>();
+    coordinator->SetLLMClient(
+        std::make_shared<fcitx::LLMClient>(fcitx::LLMClient::Config{}));
+    coordinator->Start(1, 1);
+    Register(*coordinator, 1);
+    Register(*coordinator, 2);
+
+    coordinator->HandleAsrResult("A", true, 1);
+    coordinator->HandleAsrResult("B", true, 2);
+
+    if (!Check(coordinator->ResultQueue().Size() == 4,
+               "missing LLM completion must fall back and unblock B")) {
+        return false;
+    }
+    AsrResult result;
+    const uint64_t expectedIds[] = {1, 1, 2, 2};
+    for (uint64_t expectedId : expectedIds) {
+        if (!Check(coordinator->ResultQueue().TryPop(result),
+                   "raw and refined fallback results must be available") ||
+            !Check(result.utteranceId == expectedId,
+                   "fallback results must preserve utterance order")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool TestCloseWaitsForEnteredNotification() {
+    auto coordinator = std::make_shared<ResultCoordinator>();
+    coordinator->Start(1, 1);
+    Register(*coordinator, 1);
+
+    std::promise<void> notificationEntered;
+    std::promise<void> releaseNotification;
+    auto release = releaseNotification.get_future().share();
+    std::atomic<int> notifications{0};
+    coordinator->SetResultCallback([&](const std::string&) {
+        ++notifications;
+        notificationEntered.set_value();
+        release.wait();
+    });
+
+    auto publisher = std::async(std::launch::async, [coordinator] {
+        coordinator->HandleAsrResult("A", true, 1);
+    });
+    notificationEntered.get_future().wait();
+
+    auto closer = std::async(std::launch::async, [coordinator] {
+        coordinator->Close(2);
+    });
+    const bool closeBlocked =
+        closer.wait_for(20ms) == std::future_status::timeout;
+    releaseNotification.set_value();
+
+    const bool publisherFinished =
+        publisher.wait_for(1s) == std::future_status::ready;
+    const bool closeFinished =
+        closer.wait_for(1s) == std::future_status::ready;
+    Register(*coordinator, 2);
+    coordinator->HandleAsrResult("late", true, 2);
+
+    return Check(closeBlocked,
+                 "Close must wait for an entered notification callback") &&
+           Check(publisherFinished,
+                 "notification callback must finish") &&
+           Check(closeFinished,
+                 "Close must finish after the callback exits") &&
+           Check(notifications.load() == 1,
+                 "callbacks after Close returns must be rejected");
+}
+
+} // namespace
+
+int main() {
+    return TestMoreThan128TerminalResultsAreRetained() &&
+                   TestSkippedSessionRejectsLateCallback() &&
+                   TestLlmWithoutCompletionFallsBackToTerminalRawText() &&
+                   TestCloseWaitsForEnteredNotification()
+               ? 0
+               : 1;
+}


### PR DESCRIPTION
Closes #25

## 变更
- 在 VAD Begin 时分配语音段序号，按 A→B 顺序交付 ASR 与 LLM 结果。
- 删除 final 回调清空全局 resultQueue 的逻辑；短句取消、会话超限、后端热更新及失败会话均显式跳过对应段，防止后续结果永久等待。
- 将三个后端的 worker 启动延后到 Pipeline 完成 session 映射之后，消除快速回调丢失终态的竞态。
- 统一最多 3 个活跃会话的最旧会话取消策略，修复 VAD 触发帧重复发送。
- LLM 流式响应缺少 [DONE] 时回退原始 ASR 文本，保证终态。

## 验证
- cmake -S . -B build -DBUILD_TESTS=ON && cmake --build build && ctest --test-dir build --output-on-failure
- Release 构建成功。
- CPack DEB 打包成功。
- 独立并发/生命周期审查通过。