### PR TITLE
fix(pipewire): preserve unaligned audio samples

### DIFF
--- a/src/addon/capture/audio_buffer_segments.h
+++ b/src/addon/capture/audio_buffer_segments.h
@@ -6,24 +6,31 @@
 
 namespace fcitx {
 
-// 按 SPA chunk 的环形字节偏移遍历连续的 float PCM 片段。
+// 按 SPA chunk 的环形字节偏移与 stride 遍历 float PCM 片段。
 template <typename Emit>
 void ForEachCircularFloatSegment(const float* data, uint32_t maxSize,
-                                 uint32_t offset, uint32_t size, Emit&& emit) {
+                                 uint32_t offset, uint32_t size, int32_t stride,
+                                 Emit&& emit) {
+    constexpr int32_t kPackedFloatStride = sizeof(float);
     if (!data || maxSize < sizeof(float) ||
-        maxSize % sizeof(float) != 0 || offset % sizeof(float) != 0 ||
-        size % sizeof(float) != 0) {
+        (stride != 0 && stride != kPackedFloatStride)) {
         return;
     }
 
     const uint32_t validSize = std::min(size, maxSize);
+    const uint32_t start = offset % maxSize;
+    if (maxSize % sizeof(float) != 0 || start % sizeof(float) != 0 ||
+        validSize % sizeof(float) != 0) {
+        return;
+    }
+
     const size_t capacity = maxSize / sizeof(float);
-    const size_t start = ((offset % maxSize) / sizeof(float)) % capacity;
+    const size_t sampleStart = start / sizeof(float);
     const size_t count = validSize / sizeof(float);
-    const size_t first = std::min(count, capacity - start);
+    const size_t first = std::min(count, capacity - sampleStart);
 
     if (first > 0) {
-        emit(data + start, first);
+        emit(data + sampleStart, first);
     }
     if (count > first) {
         emit(data, count - first);

--- a/src/addon/capture/audio_buffer_segments.h
+++ b/src/addon/capture/audio_buffer_segments.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace fcitx {
+
+// 按 SPA chunk 的环形字节偏移遍历连续的 float PCM 片段。
+template <typename Emit>
+void ForEachCircularFloatSegment(const float* data, uint32_t maxSize,
+                                 uint32_t offset, uint32_t size, Emit&& emit) {
+    if (!data || maxSize < sizeof(float) ||
+        maxSize % sizeof(float) != 0 || offset % sizeof(float) != 0 ||
+        size % sizeof(float) != 0) {
+        return;
+    }
+
+    const uint32_t validSize = std::min(size, maxSize);
+    const size_t capacity = maxSize / sizeof(float);
+    const size_t start = ((offset % maxSize) / sizeof(float)) % capacity;
+    const size_t count = validSize / sizeof(float);
+    const size_t first = std::min(count, capacity - start);
+
+    if (first > 0) {
+        emit(data + start, first);
+    }
+    if (count > first) {
+        emit(data, count - first);
+    }
+}
+
+} // namespace fcitx

--- a/src/addon/capture/audio_frame_assembler.h
+++ b/src/addon/capture/audio_frame_assembler.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+#include "types.h"
+
+namespace fcitx {
+
+// 将任意长度的 float PCM 连续组装为固定大小的音频帧。
+class AudioFrameAssembler {
+public:
+    template <typename Emit>
+    void Append(const float* samples, size_t count, Emit&& emit) {
+        while (count > 0) {
+            const size_t copied = std::min(count, kWindowSize - pendingSamples_);
+            std::copy_n(samples, copied, pending_.data() + pendingSamples_);
+            samples += copied;
+            count -= copied;
+            pendingSamples_ += copied;
+
+            if (pendingSamples_ == kWindowSize) {
+                emit(pending_);
+                pendingSamples_ = 0;
+            }
+        }
+    }
+
+    size_t PendingSamples() const { return pendingSamples_; }
+
+    void Reset() { pendingSamples_ = 0; }
+
+private:
+    std::array<float, kWindowSize> pending_{};
+    size_t pendingSamples_ = 0;
+};
+
+} // namespace fcitx

--- a/src/addon/capture/pipewire_capture.cpp
+++ b/src/addon/capture/pipewire_capture.cpp
@@ -299,7 +299,7 @@ void PipeWireCapture::OnProcessImpl() {
     }
 
     ForEachCircularFloatSegment(static_cast<const float*>(src), data.maxsize,
-                                chunk->offset, chunk->size,
+                                chunk->offset, chunk->size, chunk->stride,
                                 [this](const float* pcm, size_t frames) {
                                     PushSamples(pcm, frames);
                                 });

--- a/src/addon/capture/pipewire_capture.cpp
+++ b/src/addon/capture/pipewire_capture.cpp
@@ -9,6 +9,8 @@
 #include <spa/param/audio/format-utils.h>
 #include <fcitx-utils/log.h>
 
+#include "capture/audio_buffer_segments.h"
+
 namespace fcitx {
 namespace {
 
@@ -100,6 +102,10 @@ bool PipeWireCapture::Start() {
     if (running_) return true;
 
     if (!LoadLib()) return false;
+
+    frameAssembler_.Reset();
+    ringBufferDroppedSamples_ = 0;
+    drainDiscardedSamples_ = 0;
 
     pw_.pw_init(nullptr, nullptr);
 
@@ -197,14 +203,35 @@ bool PipeWireCapture::Start() {
 void PipeWireCapture::Stop() {
     if (!running_) return;
 
-    // Stop drain thread first
+    // 先停止 PipeWire 回调，再关闭 drain，避免 drain 已退出后继续写入 ring buffer。
+    if (loop_) {
+        pw_.pw_thread_loop_stop(loop_);
+    }
+
     drainRunning_ = false;
     if (drainThread_ && drainThread_->joinable()) {
         drainThread_->join();
         drainThread_.reset();
     }
 
-    Cleanup(true);
+    size_t discarded = frameAssembler_.PendingSamples();
+    float discardBuffer[kWindowSize];
+    while (true) {
+        const size_t read = ringBuffer_->Read(discardBuffer, kWindowSize);
+        if (read == 0) break;
+        discarded += read;
+    }
+    frameAssembler_.Reset();
+    drainDiscardedSamples_.fetch_add(discarded, std::memory_order_relaxed);
+
+    const auto ringDropped = ringBufferDroppedSamples_.exchange(0);
+    const auto drainDiscarded = drainDiscardedSamples_.exchange(0);
+    if (ringDropped > 0 || drainDiscarded > 0) {
+        FCITX_WARN() << "[voice-input:pw] Audio samples dropped: ring="
+                     << ringDropped << " drain=" << drainDiscarded;
+    }
+
+    Cleanup(false);
     UnloadLib();
     running_ = false;
     FCITX_INFO() << "[voice-input:pw] Capture stopped";
@@ -249,7 +276,6 @@ void PipeWireCapture::OnStateChanged(void* userdata, pw_stream_state oldState,
 void PipeWireCapture::OnProcessImpl() {
     pw_buffer* buf = pw_.pw_stream_dequeue_buffer(stream_);
     if (!buf) {
-        FCITX_DEBUG() << "[voice-input:pw] dequeue_buffer returned null";
         return;
     }
 
@@ -259,28 +285,36 @@ void PipeWireCapture::OnProcessImpl() {
         return;
     }
 
-    void* src = spa_buf->datas[0].data;
-    auto* chunk = spa_buf->datas[0].chunk;
+    const auto& data = spa_buf->datas[0];
+    void* src = data.data;
+    auto* chunk = data.chunk;
     if (!chunk) {
         pw_.pw_stream_queue_buffer(stream_, buf);
         return;
     }
-    uint32_t size = chunk->size;
 
-    if (!src || size == 0) {
+    if (!src || data.maxsize == 0 || chunk->size == 0) {
         pw_.pw_stream_queue_buffer(stream_, buf);
         return;
     }
 
-    size_t frames = size / sizeof(float);
-    const float* pcm = static_cast<const float*>(src);
-    ringBuffer_->Write(pcm, frames);
-
-    if (rawCallback_) {
-        rawCallback_(pcm, frames);
-    }
+    ForEachCircularFloatSegment(static_cast<const float*>(src), data.maxsize,
+                                chunk->offset, chunk->size,
+                                [this](const float* pcm, size_t frames) {
+                                    PushSamples(pcm, frames);
+                                });
 
     pw_.pw_stream_queue_buffer(stream_, buf);
+}
+
+void PipeWireCapture::PushSamples(const float* pcm, size_t frames) {
+    if (frames == 0) return;
+
+    const size_t written = ringBuffer_->Write(pcm, frames);
+    if (written < frames) {
+        ringBufferDroppedSamples_.fetch_add(frames - written,
+                                            std::memory_order_relaxed);
+    }
 }
 
 void PipeWireCapture::DrainLoop() {
@@ -289,26 +323,30 @@ void PipeWireCapture::DrainLoop() {
 
     while (drainRunning_) {
         size_t read = ringBuffer_->Read(floatBuf, kDrainChunk);
-        if (read < kDrainChunk) {
+        if (read == 0) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
             continue;
         }
 
-        if (!frameQueue_) continue;
+        frameAssembler_.Append(floatBuf, read,
+            [this](const std::array<float, kWindowSize>& samples) {
+                if (!frameQueue_) return;
 
-        AudioFrame frame;
-        frame.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                 std::chrono::steady_clock::now().time_since_epoch())
-                                 .count();
+                AudioFrame frame;
+                frame.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                         std::chrono::steady_clock::now().time_since_epoch())
+                                         .count();
 
-        static constexpr float kFloatToInt16 = 32767.0f;
-        for (size_t i = 0; i < kDrainChunk; ++i) {
-            float s = std::clamp(floatBuf[i], -1.0f, 1.0f);
-            frame.pcm[i] = static_cast<int16_t>(s * kFloatToInt16);
-        }
+                static constexpr float kFloatToInt16 = 32767.0f;
+                for (size_t i = 0; i < samples.size(); ++i) {
+                    float s = std::clamp(samples[i], -1.0f, 1.0f);
+                    frame.pcm[i] = static_cast<int16_t>(s * kFloatToInt16);
+                }
 
-        frameQueue_->Push(frame);
+                frameQueue_->Push(frame);
+            });
     }
+
 }
 
 } // namespace fcitx

--- a/src/addon/capture/pipewire_capture.h
+++ b/src/addon/capture/pipewire_capture.h
@@ -1,21 +1,20 @@
 #pragma once
 
 #include <atomic>
-#include <functional>
+#include <cstdint>
 #include <memory>
 #include <thread>
 
 #include <pipewire/pipewire.h>
 
 #include "capture/audio_capture.h"
+#include "capture/audio_frame_assembler.h"
 #include "utils/audio_buffer.h"
 
 namespace fcitx {
 
 class PipeWireCapture : public AudioCapture {
 public:
-    using AudioDataCallback = std::function<void(const float* pcm, size_t frames)>;
-
     PipeWireCapture();
     ~PipeWireCapture() override;
 
@@ -27,8 +26,6 @@ public:
     bool IsRunning() const override { return running_; }
     const char* Name() const override { return "pipewire"; }
 
-    void SetRawCallback(AudioDataCallback cb) { rawCallback_ = std::move(cb); }
-
 private:
     static void OnProcess(void* userdata);
     static void OnStateChanged(void* userdata, pw_stream_state oldState,
@@ -38,6 +35,7 @@ private:
     void UnloadLib();
     void Cleanup(bool stopLoop);
     void DrainLoop();
+    void PushSamples(const float* pcm, size_t frames);
 
     // 运行期 dlopen + dlsym 函数指针表。所有 pw_* 调用经由此表间接调用，
     // addon 无任何 pw_* 未定义符号——即使 Arch 构建的 DF_1_NOW (-z,now)
@@ -80,10 +78,12 @@ private:
     pw_stream* stream_ = nullptr;
 
     std::unique_ptr<AudioRingBuffer> ringBuffer_;
+    AudioFrameAssembler frameAssembler_;
     std::unique_ptr<std::thread> drainThread_;
     std::atomic<bool> running_{false};
     std::atomic<bool> drainRunning_{false};
-    AudioDataCallback rawCallback_;
+    std::atomic<uint64_t> ringBufferDroppedSamples_{0};
+    std::atomic<uint64_t> drainDiscardedSamples_{0};
 
     spa_hook streamListener_{};
     spa_hook coreListener_{};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,3 +9,13 @@ target_include_directories(session_worker_completion_test PRIVATE
 add_test(NAME session_worker_completion_test
     COMMAND session_worker_completion_test
 )
+
+add_executable(audio_frame_assembler_test
+    audio_frame_assembler_test.cpp
+)
+
+target_include_directories(audio_frame_assembler_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+)
+
+add_test(NAME audio_frame_assembler_test COMMAND audio_frame_assembler_test)

--- a/tests/audio_frame_assembler_test.cpp
+++ b/tests/audio_frame_assembler_test.cpp
@@ -1,6 +1,8 @@
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 #include "capture/audio_buffer_segments.h"
@@ -57,7 +59,7 @@ bool TestCircularBufferOffsetPreservesValidOrder() {
     std::vector<float> output;
     fcitx::ForEachCircularFloatSegment(
         source.data(), source.size() * sizeof(float), 6 * sizeof(float),
-        4 * sizeof(float),
+        4 * sizeof(float), sizeof(float),
         [&output](const float* segment, size_t count) {
             output.insert(output.end(), segment, segment + count);
         });
@@ -66,11 +68,70 @@ bool TestCircularBufferOffsetPreservesValidOrder() {
                  "a wrapped SPA chunk must begin at its offset");
 }
 
+bool TestUnexpectedStrideIsRejected() {
+    const std::array<float, 8> source{0, -1, 2, -1, 4, -1, 6, -1};
+    size_t emitted = 0;
+    constexpr std::array<int32_t, 7> invalidStrides{
+        std::numeric_limits<int32_t>::min(), -4, 1, 2, 3, 5, 8};
+    for (int32_t stride : invalidStrides) {
+        fcitx::ForEachCircularFloatSegment(
+            source.data(), source.size() * sizeof(float), 0,
+            source.size() * sizeof(float), stride,
+            [&emitted](const float*, size_t count) { emitted += count; });
+    }
+
+    return Check(emitted == 0, "a non-mono-F32 stride must be rejected");
+}
+
+bool TestZeroStrideUsesPackedSamples() {
+    const std::array<float, 3> source{1, 2, 3};
+    std::vector<float> output;
+    fcitx::ForEachCircularFloatSegment(
+        source.data(), source.size() * sizeof(float), 0,
+        source.size() * sizeof(float), 0,
+        [&output](const float* segment, size_t count) {
+            output.insert(output.end(), segment, segment + count);
+        });
+
+    return Check(output == std::vector<float>({1, 2, 3}),
+                 "zero stride must retain packed-audio compatibility");
+}
+
+bool TestChunkSizeIsClampedToCapacity() {
+    const std::array<float, 4> source{0, 1, 2, 3};
+    std::vector<float> output;
+    fcitx::ForEachCircularFloatSegment(
+        source.data(), source.size() * sizeof(float), 6 * sizeof(float),
+        std::numeric_limits<uint32_t>::max(), sizeof(float),
+        [&output](const float* segment, size_t count) {
+            output.insert(output.end(), segment, segment + count);
+        });
+
+    return Check(output == std::vector<float>({2, 3, 0, 1}),
+                 "SPA chunk size must be clamped before traversal");
+}
+
+bool TestUnalignedChunkIsRejected() {
+    const std::array<float, 4> source{0, 1, 2, 3};
+    size_t emitted = 0;
+    auto count = [&emitted](const float*, size_t size) { emitted += size; };
+    fcitx::ForEachCircularFloatSegment(source.data(), sizeof(source), 1,
+                                       sizeof(source), sizeof(float), count);
+    fcitx::ForEachCircularFloatSegment(source.data(), sizeof(source), 0,
+                                       sizeof(source) - 1, sizeof(float), count);
+
+    return Check(emitted == 0, "unaligned float chunks must be rejected");
+}
+
 } // namespace
 
 int main() {
     return TestUnalignedBlocksPreserveEverySample() &&
-                   TestCircularBufferOffsetPreservesValidOrder()
+                   TestCircularBufferOffsetPreservesValidOrder() &&
+                   TestUnexpectedStrideIsRejected() &&
+                   TestZeroStrideUsesPackedSamples() &&
+                   TestChunkSizeIsClampedToCapacity() &&
+                   TestUnalignedChunkIsRejected()
                ? 0
                : 1;
 }

--- a/tests/audio_frame_assembler_test.cpp
+++ b/tests/audio_frame_assembler_test.cpp
@@ -1,0 +1,76 @@
+#include <array>
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+#include "capture/audio_buffer_segments.h"
+#include "capture/audio_frame_assembler.h"
+
+namespace {
+
+bool Check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+    }
+    return condition;
+}
+
+bool TestUnalignedBlocksPreserveEverySample() {
+    fcitx::AudioFrameAssembler assembler;
+    std::vector<float> source(2048);
+    for (size_t i = 0; i < source.size(); ++i) {
+        source[i] = static_cast<float>(i);
+    }
+
+    std::vector<float> output;
+    auto emit = [&output](const std::array<float, fcitx::kWindowSize>& frame) {
+        output.insert(output.end(), frame.begin(), frame.end());
+    };
+
+    assembler.Append(source.data(), 256, emit);
+    assembler.Append(source.data() + 256, 480, emit);
+    assembler.Append(source.data() + 736, 960, emit);
+    if (!Check(output.size() == 1536, "three complete frames must be emitted")) {
+        return false;
+    }
+    if (!Check(assembler.PendingSamples() == 160,
+               "the remaining samples must be retained")) {
+        return false;
+    }
+
+    assembler.Append(source.data() + 1696, 352, emit);
+    if (!Check(output.size() == source.size(),
+               "the final block must complete the fourth frame")) {
+        return false;
+    }
+    for (size_t i = 0; i < source.size(); ++i) {
+        if (!Check(output[i] == source[i], "audio samples must remain contiguous")) {
+            return false;
+        }
+    }
+    return Check(assembler.PendingSamples() == 0,
+                 "no samples must remain after an exact number of frames");
+}
+
+bool TestCircularBufferOffsetPreservesValidOrder() {
+    const std::array<float, 8> source{0, 1, 2, 3, 4, 5, 6, 7};
+    std::vector<float> output;
+    fcitx::ForEachCircularFloatSegment(
+        source.data(), source.size() * sizeof(float), 6 * sizeof(float),
+        4 * sizeof(float),
+        [&output](const float* segment, size_t count) {
+            output.insert(output.end(), segment, segment + count);
+        });
+
+    return Check(output == std::vector<float>({6, 7, 0, 1}),
+                 "a wrapped SPA chunk must begin at its offset");
+}
+
+} // namespace
+
+int main() {
+    return TestUnalignedBlocksPreserveEverySample() &&
+                   TestCircularBufferOffsetPreservesValidOrder()
+               ? 0
+               : 1;
+}


### PR DESCRIPTION
Closes #24

## 修复内容
- 保留 256、480、960 等非 512 对齐 PipeWire quantum 的尾部采样，连续组装为 512-sample VAD 帧
- 按 SPA chunk offset 读取音频，并处理循环缓冲区末尾回绕
- Stop 时先停止 PipeWire 回调，再排空残留采样，避免下一次 Start 重放旧音频
- 记录 ring buffer 溢出和停止时残留丢弃；实时回调只保留缓冲写入与原子计数

## 验证
- 测试构建：cmake -S . -B .tmp/issue24-tests -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTS=ON
- 单元测试：cmake --build .tmp/issue24-tests -j4；ctest --test-dir .tmp/issue24-tests --output-on-failure
- Release 构建：cmake -S . -B .tmp/issue24-release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTS=OFF；cmake --build .tmp/issue24-release -j4
- DEB 打包：在 .tmp/issue24-release 目录执行 cpack -G DEB