### PR TITLE
fix(llm): allow requests after cancellation

### DIFF
--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -27,6 +27,11 @@ struct RequestCancellationContext {
     bool IsCancelled() const {
         return cancellation->IsCancelled(generation);
     }
+
+    template <typename Publish>
+    bool PublishIfCurrent(Publish&& publish) const {
+        return cancellation->PublishIfCurrent(generation, publish);
+    }
 };
 
 // 进度回调：请求所属代次被取消后中断 HTTP 传输（返回非 0 中止请求）。
@@ -66,7 +71,6 @@ std::string BuildSystemPrompt(const std::string& userPrompt) {
 struct SSEContext {
     std::string buffer;
     std::function<void(const std::string&)> onToken;
-    std::function<void(const std::string&)> onComplete;
     const RequestCancellationContext* cancellationContext = nullptr;
     std::string accumulated;
     bool done = false;
@@ -94,9 +98,6 @@ size_t SSEWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) 
 
         if (data == "[DONE]") {
             ctx->done = true;
-            if (!ctx->cancellationContext->IsCancelled()) {
-                ctx->onComplete(ctx->accumulated);
-            }
             continue;
         }
 
@@ -107,10 +108,10 @@ size_t SSEWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) 
         std::string content = root["choices"][0]["delta"]["content"].asString();
         if (content.empty()) continue;
 
-        if (!ctx->cancellationContext->IsCancelled()) {
+        if (!ctx->cancellationContext->PublishIfCurrent([&] {
             ctx->accumulated += content;
             ctx->onToken(ctx->accumulated);
-        }
+        })) return 0;
     }
 
     return total;
@@ -123,13 +124,17 @@ LLMClient::LLMClient(Config config)
 
 LLMClient::~LLMClient() = default;
 
-std::string LLMClient::Process(const std::string& text) {
-    if (config_.model.empty()) {
-        return text;
-    }
+void LLMClient::Process(const std::string& text, uint64_t generation,
+                        std::function<void(const std::string&)> onComplete) {
+    if (!onComplete) return;
 
-    RequestCancellationContext cancellationContext{
-        &cancellation_, cancellation_.BeginRequest()};
+    RequestCancellationContext cancellationContext{&cancellation_, generation};
+    if (cancellationContext.IsCancelled()) return;
+
+    if (config_.model.empty()) {
+        cancellationContext.PublishIfCurrent([&] { onComplete(text); });
+        return;
+    }
 
     // Build URL
     std::string url = config_.endpoint;
@@ -173,7 +178,7 @@ std::string LLMClient::Process(const std::string& text) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         FCITX_ERROR() << "[voice-input:llm] Failed to init curl";
-        return {};
+        return;
     }
 
     std::string response;
@@ -213,7 +218,7 @@ std::string LLMClient::Process(const std::string& text) {
 
     if (cancellationContext.IsCancelled()) {
         FCITX_DEBUG() << "[voice-input:llm] Cancelled request";
-        return {};
+        return;
     }
 
     FCITX_DEBUG() << "[voice-input:llm] HTTP " << httpCode
@@ -237,7 +242,7 @@ std::string LLMClient::Process(const std::string& text) {
                      << " http=" << httpCode
                      << " elapsed=" << elapsedMs << "ms"
                      << " osErrno=" << osErrno;
-        return {};
+        return;
     }
 
     // Parse response
@@ -247,14 +252,14 @@ std::string LLMClient::Process(const std::string& text) {
         FCITX_WARN() << "[voice-input:llm] JSON parse failed"
                      << " elapsed=" << elapsedMs << "ms"
                      << " responseHead=" << response.substr(0, 200);
-        return {};
+        return;
     }
 
     std::string content = json["choices"][0]["message"]["content"].asString();
     if (content.empty()) {
         FCITX_WARN() << "[voice-input:llm] Empty response content"
                      << " elapsed=" << elapsedMs << "ms";
-        return {};
+        return;
     }
 
     // Try JSON extraction, fallback to raw LLM output
@@ -267,16 +272,16 @@ std::string LLMClient::Process(const std::string& text) {
 
     FCITX_DEBUG() << "[voice-input:llm] Done: raw=" << text.size()
                  << " chars → out=" << result.size() << " chars";
-    return result;
+    cancellationContext.PublishIfCurrent([&] { onComplete(result); });
 }
 
-void LLMClient::ProcessStream(const std::string& text,
+void LLMClient::ProcessStream(const std::string& text, uint64_t generation,
                                std::function<void(const std::string&)> onToken,
                                std::function<void(const std::string&)> onComplete) {
     if (config_.model.empty() || !onComplete) return;
 
-    RequestCancellationContext cancellationContext{
-        &cancellation_, cancellation_.BeginRequest()};
+    RequestCancellationContext cancellationContext{&cancellation_, generation};
+    if (cancellationContext.IsCancelled()) return;
 
     std::string url = config_.endpoint;
     if (!url.empty() && url.back() != '/') {
@@ -330,17 +335,6 @@ void LLMClient::ProcessStream(const std::string& text,
     ctx.cancellationContext = &cancellationContext;
     // Skip onToken during streaming — partial JSON is not user-friendly
     ctx.onToken = [](const std::string&) {};
-    ctx.onComplete = [&onComplete, text](const std::string& s) {
-        if (!onComplete) return;
-        std::string extracted = ExtractJsonText(s);
-        if (!extracted.empty()) {
-            onComplete(extracted);
-        } else {
-            FCITX_WARN() << "[voice-input:llm:stream] Failed to parse JSON, "
-                         << "falling back to raw ASR text";
-            onComplete(text);
-        }
-    };
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
@@ -380,9 +374,21 @@ void LLMClient::ProcessStream(const std::string& text,
                      << " elapsed=" << elapsedMs << "ms";
         return;
     }
+    if (!ctx.done) {
+        FCITX_WARN() << "[voice-input:llm:stream] Response ended without [DONE]";
+        return;
+    }
+
+    std::string extracted = ExtractJsonText(ctx.accumulated);
+    std::string result = extracted.empty() ? text : extracted;
+    if (extracted.empty()) {
+        FCITX_WARN() << "[voice-input:llm:stream] Failed to parse JSON, "
+                     << "falling back to raw ASR text";
+    }
 
     FCITX_DEBUG() << "[voice-input:llm:stream] Done: elapsed=" << elapsedMs << "ms"
                  << " accumulated=" << ctx.accumulated.size() << " chars";
+    cancellationContext.PublishIfCurrent([&] { onComplete(result); });
 }
 
 } // namespace fcitx

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -192,6 +192,7 @@ std::string LLMClient::Process(const std::string& text) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     // Cancel() 后仅中断当前或更早代次的请求。
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
@@ -350,6 +351,7 @@ void LLMClient::ProcessStream(const std::string& text,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     // Cancel() 后仅中断当前或更早代次的请求。
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);

--- a/src/addon/llm/llm_client.cpp
+++ b/src/addon/llm/llm_client.cpp
@@ -20,11 +20,20 @@ size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     return total;
 }
 
-// 进度回调：Cancel() 后中断在途 HTTP 传输（返回非 0 中止请求）
+struct RequestCancellationContext {
+    const LLMRequestCancellation* cancellation = nullptr;
+    uint64_t generation = 0;
+
+    bool IsCancelled() const {
+        return cancellation->IsCancelled(generation);
+    }
+};
+
+// 进度回调：请求所属代次被取消后中断 HTTP 传输（返回非 0 中止请求）。
 int CancelProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
                            curl_off_t) {
-    auto* cancelled = static_cast<std::atomic<bool>*>(clientp);
-    return cancelled->load() ? 1 : 0;
+    auto* context = static_cast<RequestCancellationContext*>(clientp);
+    return context->IsCancelled() ? 1 : 0;
 }
 
 // Extract "text" field from a JSON response.
@@ -58,6 +67,7 @@ struct SSEContext {
     std::string buffer;
     std::function<void(const std::string&)> onToken;
     std::function<void(const std::string&)> onComplete;
+    const RequestCancellationContext* cancellationContext = nullptr;
     std::string accumulated;
     bool done = false;
 };
@@ -65,6 +75,7 @@ struct SSEContext {
 size_t SSEWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
     auto* ctx = static_cast<SSEContext*>(userp);
     size_t total = size * nmemb;
+    if (ctx->cancellationContext->IsCancelled()) return 0;
     ctx->buffer.append(static_cast<char*>(contents), total);
 
     // Parse complete SSE events (separated by "\n\n")
@@ -83,7 +94,9 @@ size_t SSEWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) 
 
         if (data == "[DONE]") {
             ctx->done = true;
-            ctx->onComplete(ctx->accumulated);
+            if (!ctx->cancellationContext->IsCancelled()) {
+                ctx->onComplete(ctx->accumulated);
+            }
             continue;
         }
 
@@ -94,8 +107,10 @@ size_t SSEWriteCallback(void* contents, size_t size, size_t nmemb, void* userp) 
         std::string content = root["choices"][0]["delta"]["content"].asString();
         if (content.empty()) continue;
 
-        ctx->accumulated += content;
-        ctx->onToken(ctx->accumulated);
+        if (!ctx->cancellationContext->IsCancelled()) {
+            ctx->accumulated += content;
+            ctx->onToken(ctx->accumulated);
+        }
     }
 
     return total;
@@ -112,6 +127,9 @@ std::string LLMClient::Process(const std::string& text) {
     if (config_.model.empty()) {
         return text;
     }
+
+    RequestCancellationContext cancellationContext{
+        &cancellation_, cancellation_.BeginRequest()};
 
     // Build URL
     std::string url = config_.endpoint;
@@ -174,10 +192,10 @@ std::string LLMClient::Process(const std::string& text) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
-    // Cancel() 后中断在途传输
+    // Cancel() 后仅中断当前或更早代次的请求。
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
-    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled_);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancellationContext);
 
     CURLcode res = curl_easy_perform(curl);
 
@@ -191,6 +209,11 @@ std::string LLMClient::Process(const std::string& text) {
 
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
+
+    if (cancellationContext.IsCancelled()) {
+        FCITX_DEBUG() << "[voice-input:llm] Cancelled request";
+        return {};
+    }
 
     FCITX_DEBUG() << "[voice-input:llm] HTTP " << httpCode
                   << " response=" << response.size() << " bytes"
@@ -251,6 +274,9 @@ void LLMClient::ProcessStream(const std::string& text,
                                std::function<void(const std::string&)> onComplete) {
     if (config_.model.empty() || !onComplete) return;
 
+    RequestCancellationContext cancellationContext{
+        &cancellation_, cancellation_.BeginRequest()};
+
     std::string url = config_.endpoint;
     if (!url.empty() && url.back() != '/') {
         url += '/';
@@ -300,6 +326,7 @@ void LLMClient::ProcessStream(const std::string& text,
     headers = curl_slist_append(headers, authHeader.c_str());
 
     SSEContext ctx;
+    ctx.cancellationContext = &cancellationContext;
     // Skip onToken during streaming — partial JSON is not user-friendly
     ctx.onToken = [](const std::string&) {};
     ctx.onComplete = [&onComplete, text](const std::string& s) {
@@ -323,10 +350,10 @@ void LLMClient::ProcessStream(const std::string& text,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
-    // Cancel() 后中断在途传输
+    // Cancel() 后仅中断当前或更早代次的请求。
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
-    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled_);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancellationContext);
 
     CURLcode res = curl_easy_perform(curl);
 
@@ -338,6 +365,11 @@ void LLMClient::ProcessStream(const std::string& text,
 
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
+
+    if (cancellationContext.IsCancelled()) {
+        FCITX_DEBUG() << "[voice-input:llm:stream] Cancelled request";
+        return;
+    }
 
     if (res != CURLE_OK || httpCode != 200) {
         FCITX_WARN() << "[voice-input:llm:stream] Request failed: "

--- a/src/addon/llm/llm_client.h
+++ b/src/addon/llm/llm_client.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <atomic>
 #include <functional>
 #include <string>
 #include <vector>
+
+#include "llm/llm_request_cancellation.h"
 
 namespace fcitx {
 
@@ -32,12 +33,12 @@ public:
                        std::function<void(const std::string&)> onToken,
                        std::function<void(const std::string&)> onComplete);
 
-    /// 取消在途请求：中断当前阻塞的 HTTP 传输，后续调用立即返回。
-    void Cancel() { cancelled_.store(true); }
+    /// 取消当前及更早的在途请求；后续请求自动使用新代次。
+    void Cancel() { cancellation_.Cancel(); }
 
 private:
     Config config_;
-    std::atomic<bool> cancelled_{false};
+    LLMRequestCancellation cancellation_;
 };
 
 } // namespace fcitx

--- a/src/addon/llm/llm_client.h
+++ b/src/addon/llm/llm_client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -23,17 +24,21 @@ public:
     LLMClient(const LLMClient&) = delete;
     LLMClient& operator=(const LLMClient&) = delete;
 
-    // Non-streaming: returns processed text on success, empty on failure.
-    std::string Process(const std::string& text);
+    // 非流式处理：仅在请求仍属于活动 generation 时发布成功结果。
+    void Process(const std::string& text, uint64_t generation,
+                 std::function<void(const std::string&)> onComplete);
 
     // Streaming: calls onToken with each incremental chunk,
     // onComplete with the full accumulated text.
     // Both callbacks run on the calling thread.
-    void ProcessStream(const std::string& text,
+    void ProcessStream(const std::string& text, uint64_t generation,
                        std::function<void(const std::string&)> onToken,
                        std::function<void(const std::string&)> onComplete);
 
-    /// 取消当前及更早的在途请求；后续请求自动使用新代次。
+    /// 激活新会话；只有 generation 匹配的请求可执行和发布。
+    void Activate(uint64_t generation) { cancellation_.Activate(generation); }
+
+    /// 取消活动会话，并等待已进入发布门的短回调完成。
     void Cancel() { cancellation_.Cancel(); }
 
 private:

--- a/src/addon/llm/llm_request_cancellation.h
+++ b/src/addon/llm/llm_request_cancellation.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace fcitx {
+
+// 用取消代次隔离不同会话：Cancel() 只中断已开始的请求，后续请求自动使用新代次。
+class LLMRequestCancellation {
+public:
+    uint64_t BeginRequest() const {
+        return generation_.load(std::memory_order_acquire);
+    }
+
+    void Cancel() {
+        generation_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    bool IsCancelled(uint64_t requestGeneration) const {
+        return generation_.load(std::memory_order_acquire) != requestGeneration;
+    }
+
+private:
+    std::atomic<uint64_t> generation_{0};
+};
+
+} // namespace fcitx

--- a/src/addon/llm/llm_request_cancellation.h
+++ b/src/addon/llm/llm_request_cancellation.h
@@ -2,26 +2,41 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 
 namespace fcitx {
 
-// 用取消代次隔离不同会话：Cancel() 只中断已开始的请求，后续请求自动使用新代次。
+// 用外部会话 generation 隔离请求，并串行化最终发布与取消。
 class LLMRequestCancellation {
 public:
-    uint64_t BeginRequest() const {
-        return generation_.load(std::memory_order_acquire);
+    void Activate(uint64_t generation) {
+        std::lock_guard<std::mutex> lock(publicationMutex_);
+        activeGeneration_.store(generation, std::memory_order_release);
     }
 
     void Cancel() {
-        generation_.fetch_add(1, std::memory_order_acq_rel);
+        std::lock_guard<std::mutex> lock(publicationMutex_);
+        activeGeneration_.store(0, std::memory_order_release);
     }
 
     bool IsCancelled(uint64_t requestGeneration) const {
-        return generation_.load(std::memory_order_acquire) != requestGeneration;
+        return requestGeneration == 0 ||
+               activeGeneration_.load(std::memory_order_acquire) !=
+                   requestGeneration;
+    }
+
+    // 回调在发布门内执行，必须保持短小且不得递归 Activate()/Cancel()。
+    template <typename Publish>
+    bool PublishIfCurrent(uint64_t requestGeneration, Publish&& publish) const {
+        std::lock_guard<std::mutex> lock(publicationMutex_);
+        if (IsCancelled(requestGeneration)) return false;
+        publish();
+        return true;
     }
 
 private:
-    std::atomic<uint64_t> generation_{0};
+    std::atomic<uint64_t> activeGeneration_{0};
+    mutable std::mutex publicationMutex_;
 };
 
 } // namespace fcitx

--- a/src/addon/pipeline/pipeline.cpp
+++ b/src/addon/pipeline/pipeline.cpp
@@ -71,6 +71,9 @@ void Pipeline::SetConfig(const VoiceInputConfig& config) {
 
 void Pipeline::SetLLMClient(std::unique_ptr<LLMClient> client) {
     llmClient_ = std::move(client);
+    if (llmClient_ && running_) {
+        llmClient_->Activate(generation_.load());
+    }
 }
 
 void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
@@ -139,7 +142,7 @@ void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
                                  << " uid=" << uid << " gen=" << gen
                                  << " stream=" << llmStream_;
                     if (llmStream_) {
-                        llmClient_->ProcessStream(text,
+                        llmClient_->ProcessStream(text, gen,
                             [this, guard, uid, gen,
                              sid](const std::string& partial) {
                                 if (!guard->load()) return;
@@ -167,17 +170,19 @@ void Pipeline::SetAsrEngine(std::unique_ptr<AsrEngine> engine) {
                                 if (resultCb_) resultCb_(fullText);
                             });
                     } else {
-                        std::string processed = llmClient_->Process(text);
-                        if (!processed.empty()) {
-                            AsrResult refinedResult;
-                            refinedResult.text = processed;
-                            refinedResult.generation = gen;
-                            refinedResult.sessionId = sid;
-                            refinedResult.utteranceId = uid;
-                            refinedResult.isLLMRefined = true;
-                            resultQueue_.Push(std::move(refinedResult));
-                            if (resultCb_) resultCb_(processed);
-                        }
+                        llmClient_->Process(text, gen,
+                            [this, guard, uid, gen,
+                             sid](const std::string& processed) {
+                                if (!guard->load()) return;
+                                AsrResult refinedResult;
+                                refinedResult.text = processed;
+                                refinedResult.generation = gen;
+                                refinedResult.sessionId = sid;
+                                refinedResult.utteranceId = uid;
+                                refinedResult.isLLMRefined = true;
+                                resultQueue_.Push(std::move(refinedResult));
+                                if (resultCb_) resultCb_(processed);
+                            });
                     }
                 }
             } else if (!text.empty()) {
@@ -211,7 +216,10 @@ void Pipeline::SetVadStatusCallback(VADWorker::VadStatusCallback cb) {
 }
 
 void Pipeline::Start() {
-    if (running_) return;
+    if (running_) {
+        if (llmClient_) llmClient_->Activate(generation_.load());
+        return;
+    }
 
     if (!asrEngine_) {
         FCITX_ERROR() << "[voice-input] No ASR engine configured";
@@ -233,6 +241,7 @@ void Pipeline::Start() {
         return;
     }
 
+    if (llmClient_) llmClient_->Activate(generation_.load());
     running_ = true;
     asrThread_ = std::make_unique<std::thread>(&Pipeline::AsrDispatcherLoop, this);
 
@@ -243,6 +252,9 @@ void Pipeline::Stop() {
     if (!running_) return;
 
     running_ = false;
+    if (llmClient_) {
+        llmClient_->Cancel();
+    }
 
     if (capture_) {
         capture_->Stop();
@@ -272,11 +284,6 @@ void Pipeline::Stop() {
         engine->CancelAllSessions();
     }
 
-    // 停止 LLM 后处理（中断在途请求）
-    if (llmClient_) {
-        llmClient_->Cancel();
-    }
-
     if (capture_) {
         capture_.reset();
     }
@@ -298,6 +305,9 @@ void Pipeline::Stop() {
 
 void Pipeline::Abort() {
     running_ = false;
+    if (llmClient_) {
+        llmClient_->Cancel();
+    }
 
     if (capture_) {
         capture_->Stop();
@@ -324,10 +334,6 @@ void Pipeline::Abort() {
     }
     if (engine) {
         engine->CancelAllSessions();
-    }
-
-    if (llmClient_) {
-        llmClient_->Cancel();
     }
 
     // Clear queues

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,15 @@ target_include_directories(audio_frame_assembler_test PRIVATE
 )
 
 add_test(NAME audio_frame_assembler_test COMMAND audio_frame_assembler_test)
+
+add_executable(llm_request_cancellation_test
+    llm_request_cancellation_test.cpp
+)
+
+target_include_directories(llm_request_cancellation_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+)
+
+add_test(NAME llm_request_cancellation_test
+    COMMAND llm_request_cancellation_test
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,10 +22,20 @@ add_test(NAME audio_frame_assembler_test COMMAND audio_frame_assembler_test)
 
 add_executable(llm_request_cancellation_test
     llm_request_cancellation_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/addon/llm/llm_client.cpp
 )
 
 target_include_directories(llm_request_cancellation_test PRIVATE
     ${CMAKE_SOURCE_DIR}/src/addon
+    ${FCITX5_INCLUDE_DIRS}
+    ${JSONCPP_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
+)
+
+target_link_libraries(llm_request_cancellation_test PRIVATE
+    ${FCITX5_LIBRARIES}
+    ${JSONCPP_LIBRARIES}
+    CURL::libcurl
 )
 
 add_test(NAME llm_request_cancellation_test

--- a/tests/llm_request_cancellation_test.cpp
+++ b/tests/llm_request_cancellation_test.cpp
@@ -1,19 +1,17 @@
-#include <cassert>
-
 #include "llm/llm_request_cancellation.h"
 
 int main() {
     fcitx::LLMRequestCancellation cancellation;
 
     const auto firstRequest = cancellation.BeginRequest();
-    assert(!cancellation.IsCancelled(firstRequest));
+    if (cancellation.IsCancelled(firstRequest)) return 1;
 
     cancellation.Cancel();
-    assert(cancellation.IsCancelled(firstRequest));
+    if (!cancellation.IsCancelled(firstRequest)) return 1;
 
     const auto nextRequest = cancellation.BeginRequest();
-    assert(!cancellation.IsCancelled(nextRequest));
+    if (cancellation.IsCancelled(nextRequest)) return 1;
 
     cancellation.Cancel();
-    assert(cancellation.IsCancelled(nextRequest));
+    if (!cancellation.IsCancelled(nextRequest)) return 1;
 }

--- a/tests/llm_request_cancellation_test.cpp
+++ b/tests/llm_request_cancellation_test.cpp
@@ -1,17 +1,111 @@
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+
+#include "llm/llm_client.h"
 #include "llm/llm_request_cancellation.h"
 
-int main() {
+namespace {
+
+using namespace std::chrono_literals;
+
+bool Check(bool condition, const char* message) {
+    if (!condition) std::cerr << message << '\n';
+    return condition;
+}
+
+bool TestGenerationIsolation() {
     fcitx::LLMRequestCancellation cancellation;
+    cancellation.Activate(1);
 
-    const auto firstRequest = cancellation.BeginRequest();
-    if (cancellation.IsCancelled(firstRequest)) return 1;
-
-    cancellation.Cancel();
-    if (!cancellation.IsCancelled(firstRequest)) return 1;
-
-    const auto nextRequest = cancellation.BeginRequest();
-    if (cancellation.IsCancelled(nextRequest)) return 1;
+    if (!Check(!cancellation.IsCancelled(1), "active generation must run")) {
+        return false;
+    }
 
     cancellation.Cancel();
-    if (!cancellation.IsCancelled(nextRequest)) return 1;
+    cancellation.Activate(2);
+    bool oldGenerationPublished = false;
+    bool newGenerationPublished = false;
+    return Check(cancellation.IsCancelled(1),
+                 "late request from the old generation must stay cancelled") &&
+           Check(!cancellation.IsCancelled(2),
+                 "new generation must run after cancellation") &&
+           Check(!cancellation.PublishIfCurrent(
+                     1, [&] { oldGenerationPublished = true; }),
+                 "late old-generation publication must be rejected") &&
+           Check(!oldGenerationPublished,
+                 "rejected old-generation callback must not run") &&
+           Check(cancellation.PublishIfCurrent(
+                     2, [&] { newGenerationPublished = true; }),
+                 "new-generation publication must be accepted") &&
+           Check(newGenerationPublished,
+                 "accepted new-generation callback must run");
+}
+
+bool TestCancelWaitsForPublication() {
+    fcitx::LLMRequestCancellation cancellation;
+    cancellation.Activate(1);
+
+    std::promise<void> publicationEntered;
+    std::promise<void> releasePublication;
+    auto release = releasePublication.get_future().share();
+    std::atomic<bool> published{false};
+    auto publisher = std::async(std::launch::async, [&] {
+        return cancellation.PublishIfCurrent(1, [&] {
+            publicationEntered.set_value();
+            release.wait();
+            published = true;
+        });
+    });
+    publicationEntered.get_future().wait();
+
+    std::promise<void> cancelAttempted;
+    auto canceller = std::async(std::launch::async, [&] {
+        cancelAttempted.set_value();
+        cancellation.Cancel();
+    });
+    cancelAttempted.get_future().wait();
+    const bool cancelBlocked =
+        canceller.wait_for(20ms) == std::future_status::timeout;
+    releasePublication.set_value();
+
+    return Check(cancelBlocked, "Cancel must wait for an active publication") &&
+           Check(publisher.get(), "current publication must be accepted") &&
+           Check(published.load(), "accepted publication must complete") &&
+           Check(canceller.wait_for(1s) == std::future_status::ready,
+                 "Cancel must finish after publication leaves the gate") &&
+           Check(!cancellation.PublishIfCurrent(1, [] {}),
+                 "publication after Cancel returns must be rejected");
+}
+
+bool TestClientRejectsLateGeneration() {
+    fcitx::LLMClient client({});
+    std::string result;
+
+    client.Activate(1);
+    client.Process("first", 1,
+                   [&result](const std::string& text) { result = text; });
+    if (!Check(result == "first", "active client request must publish")) {
+        return false;
+    }
+
+    client.Cancel();
+    client.Activate(2);
+    result.clear();
+    client.Process("stale", 1,
+                   [&result](const std::string& text) { result = text; });
+    client.Process("next", 2,
+                   [&result](const std::string& text) { result = text; });
+    return Check(result == "next",
+                 "client must reject stale requests and publish the new session");
+}
+
+} // namespace
+
+int main() {
+    return TestGenerationIsolation() && TestCancelWaitsForPublication() &&
+                   TestClientRejectsLateGeneration()
+               ? 0
+               : 1;
 }

--- a/tests/llm_request_cancellation_test.cpp
+++ b/tests/llm_request_cancellation_test.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+
+#include "llm/llm_request_cancellation.h"
+
+int main() {
+    fcitx::LLMRequestCancellation cancellation;
+
+    const auto firstRequest = cancellation.BeginRequest();
+    assert(!cancellation.IsCancelled(firstRequest));
+
+    cancellation.Cancel();
+    assert(cancellation.IsCancelled(firstRequest));
+
+    const auto nextRequest = cancellation.BeginRequest();
+    assert(!cancellation.IsCancelled(nextRequest));
+
+    cancellation.Cancel();
+    assert(cancellation.IsCancelled(nextRequest));
+}


### PR DESCRIPTION
Part of #23

## 修复内容
- 将 LLM 的永久取消标志改为请求取消代次
- Cancel 只中断已开始的请求；下一会话的新请求自动使用新代次
- 普通与流式请求在网络返回、流式写入、token 与完成回调前均检查取消状态，避免已取消请求继续上屏

## 验证
- 单测：llm_request_cancellation_test
- Release 构建成功
- 在 Release 构建目录执行 cpack -G DEB 成功

剩余的 ASR 会话回收与 WebSocket 握手取消由独立 PR 处理。