### PR TITLE
fix(asr): reclaim completed session workers

### DIFF
--- a/src/addon/asr/asr_session.h
+++ b/src/addon/asr/asr_session.h
@@ -6,14 +6,26 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <thread>
 
 namespace fcitx {
+
+inline bool WaitForWorkerCompletion(const std::atomic<bool>& completed,
+                                    std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!completed.load(std::memory_order_acquire)) {
+        if (std::chrono::steady_clock::now() >= deadline) return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return true;
+}
 
 class AsrSession : public std::enable_shared_from_this<AsrSession> {
 public:
     struct State {
         std::atomic<bool> cancelled{false};
         std::atomic<bool> finished{false};
+        std::atomic<bool> workerDone{true};
         uint64_t sessionId{0};
     };
 

--- a/src/addon/asr/openai_asr.cpp
+++ b/src/addon/asr/openai_asr.cpp
@@ -149,9 +149,11 @@ void OpenaiAsrSession::End() {
     // 用 shared_from_this 保活会话：worker 线程可能因慢网络在 JoinWithTimeout
     // 超时后被 detach，此时会话对象仍必须存活，否则成员访问构成 use-after-free。
     auto self = std::static_pointer_cast<OpenaiAsrSession>(shared_from_this());
+    state_->workerDone.store(false, std::memory_order_release);
     workerThread_ = std::make_unique<std::thread>(
         [self, buf = std::move(buffer)]() mutable {
             self->TranscribeWorker(std::move(buf));
+            self->state_->workerDone.store(true, std::memory_order_release);
         });
 }
 
@@ -161,17 +163,16 @@ void OpenaiAsrSession::Cancel() {
 
 void OpenaiAsrSession::JoinWithTimeout(std::chrono::milliseconds timeout) {
     if (workerThread_ && workerThread_->joinable()) {
-        auto start = std::chrono::steady_clock::now();
-        while (std::chrono::steady_clock::now() - start < timeout) {
-            std::this_thread::sleep_for(10ms);
-            if (!workerThread_->joinable()) {
-                workerThread_->join();
-                return;
-            }
+        if (workerThread_->get_id() == std::this_thread::get_id()) {
+            // worker 持有最后一个会话引用时，析构会在自身线程执行，不能 join 自身。
+            workerThread_->detach();
+        } else if (WaitForWorkerCompletion(state_->workerDone, timeout)) {
+            workerThread_->join();
+        } else {
+            FCITX_WARN() << "[voice-input:openai] Join timeout session="
+                         << state_->sessionId;
+            workerThread_->detach();
         }
-        FCITX_WARN() << "[voice-input:openai] Join timeout session="
-                     << state_->sessionId;
-        workerThread_->detach();
     }
     workerThread_.reset();
 }
@@ -272,6 +273,7 @@ void OpenaiAsrSession::TranscribeWorker(std::vector<float> pcm) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
     // Cancel() 后立即中断在途传输，避免 JoinWithTimeout 超时 detach
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);

--- a/src/addon/asr/realtime_asr.cpp
+++ b/src/addon/asr/realtime_asr.cpp
@@ -48,6 +48,12 @@ std::string JsonToString(const Json::Value& json) {
     return Json::writeString(builder, json);
 }
 
+int CancelProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
+                           curl_off_t) {
+    auto* cancelled = static_cast<std::atomic<bool>*>(clientp);
+    return cancelled->load(std::memory_order_acquire) ? 1 : 0;
+}
+
 // 发送一个 TEXT WS 帧（OpenAI Realtime 用 JSON 文本帧）。
 bool SendWebSocketText(CURL* curl, const std::string& data,
                        const std::atomic<bool>& cancelFlag) {
@@ -161,7 +167,11 @@ RealtimeAsrSession::~RealtimeAsrSession() {
 void RealtimeAsrSession::StartWorker() {
     if (!state_->finished && !workerThread_) {
         auto self = std::static_pointer_cast<RealtimeAsrSession>(shared_from_this());
-        workerThread_ = std::make_unique<std::thread>([self]() { self->WorkerLoop(); });
+        state_->workerDone.store(false, std::memory_order_release);
+        workerThread_ = std::make_unique<std::thread>([self]() {
+            self->WorkerLoop();
+            self->state_->workerDone.store(true, std::memory_order_release);
+        });
     }
 }
 
@@ -188,14 +198,16 @@ void RealtimeAsrSession::Cancel() {
 
 void RealtimeAsrSession::JoinWithTimeout(std::chrono::milliseconds timeout) {
     if (workerThread_ && workerThread_->joinable()) {
-        auto start = std::chrono::steady_clock::now();
-        while (std::chrono::steady_clock::now() - start < timeout) {
-            std::this_thread::sleep_for(10ms);
-            if (!workerThread_->joinable()) { workerThread_->join(); return; }
+        if (workerThread_->get_id() == std::this_thread::get_id()) {
+            // worker 持有最后一个会话引用时，析构会在自身线程执行，不能 join 自身。
+            workerThread_->detach();
+        } else if (WaitForWorkerCompletion(state_->workerDone, timeout)) {
+            workerThread_->join();
+        } else {
+            FCITX_WARN() << "[voice-input:realtime] Join timeout session="
+                         << state_->sessionId;
+            workerThread_->detach();
         }
-        FCITX_WARN() << "[voice-input:realtime] Join timeout session="
-                     << state_->sessionId;
-        workerThread_->detach();
     }
     workerThread_.reset();
 }
@@ -257,7 +269,12 @@ void RealtimeAsrSession::WorkerLoop() {
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
         curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
         curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15L);
         curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &state_->cancelled);
 
         CURLcode connectResult = curl_easy_perform(curl);
         curl_slist_free_all(headers);

--- a/src/addon/asr/volcengine_asr.cpp
+++ b/src/addon/asr/volcengine_asr.cpp
@@ -146,6 +146,12 @@ std::string MaskSecret(const std::string& secret) {
     return secret.substr(0, 6) + "..." + secret.substr(secret.size() - 4);
 }
 
+int CancelProgressCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
+                           curl_off_t) {
+    auto* cancelled = static_cast<std::atomic<bool>*>(clientp);
+    return cancelled->load(std::memory_order_acquire) ? 1 : 0;
+}
+
 std::string ExtractHeaderValue(const std::string& headers, const std::string& name) {
     size_t pos = headers.find(name);
     if (pos == std::string::npos) return "";
@@ -355,7 +361,11 @@ VolcengineAsrSession::~VolcengineAsrSession() {
 void VolcengineAsrSession::StartWorker() {
     if (!state_->finished && !workerThread_) {
         auto self = std::static_pointer_cast<VolcengineAsrSession>(shared_from_this());
-        workerThread_ = std::make_unique<std::thread>([self]() { self->WorkerLoop(); });
+        state_->workerDone.store(false, std::memory_order_release);
+        workerThread_ = std::make_unique<std::thread>([self]() {
+            self->WorkerLoop();
+            self->state_->workerDone.store(true, std::memory_order_release);
+        });
     }
 }
 
@@ -382,13 +392,16 @@ void VolcengineAsrSession::Cancel() {
 
 void VolcengineAsrSession::JoinWithTimeout(std::chrono::milliseconds timeout) {
     if (workerThread_ && workerThread_->joinable()) {
-        auto start = std::chrono::steady_clock::now();
-        while (std::chrono::steady_clock::now() - start < timeout) {
-            std::this_thread::sleep_for(10ms);
-            if (!workerThread_->joinable()) { workerThread_->join(); return; }
+        if (workerThread_->get_id() == std::this_thread::get_id()) {
+            // worker 持有最后一个会话引用时，析构会在自身线程执行，不能 join 自身。
+            workerThread_->detach();
+        } else if (WaitForWorkerCompletion(state_->workerDone, timeout)) {
+            workerThread_->join();
+        } else {
+            FCITX_WARN() << "[voice-input:volcengine] Join timeout session="
+                         << state_->sessionId;
+            workerThread_->detach();
         }
-        FCITX_WARN() << "[voice-input:volcengine] Join timeout session=" << state_->sessionId;
-        workerThread_->detach();
     }
     workerThread_.reset();
 }
@@ -433,6 +446,10 @@ void VolcengineAsrSession::WorkerLoop() {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcitx5-voice-input/0.1.0");
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CancelProgressCallback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &state_->cancelled);
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION,
                      +[](char* buf, size_t s, size_t n, void* u) -> size_t {
                          static_cast<std::string*>(u)->append(buf, s * n); return s * n;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(session_worker_completion_test
+    session_worker_completion_test.cpp
+)
+
+target_include_directories(session_worker_completion_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/addon
+)
+
+add_test(NAME session_worker_completion_test
+    COMMAND session_worker_completion_test
+)

--- a/tests/session_worker_completion_test.cpp
+++ b/tests/session_worker_completion_test.cpp
@@ -1,0 +1,24 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "asr/asr_session.h"
+
+using namespace std::chrono_literals;
+
+int main() {
+    std::atomic<bool> completed{true};
+    if (!fcitx::WaitForWorkerCompletion(completed, 1ms)) return 1;
+
+    completed = false;
+    if (fcitx::WaitForWorkerCompletion(completed, 1ms)) return 1;
+
+    std::thread worker([&completed]() {
+        std::this_thread::sleep_for(2ms);
+        completed.store(true, std::memory_order_release);
+    });
+    const bool observedCompletion =
+        fcitx::WaitForWorkerCompletion(completed, 50ms);
+    worker.join();
+    if (!observedCompletion) return 1;
+}


### PR DESCRIPTION
Part of #23

## 修复内容
- 使用 workerDone 判断三个 ASR 后端的 worker 是否实际完成；完成后立即 join，超时才 detach
- 处理 worker 持有最后一个会话引用时在自身线程析构的场景，避免 self-join
- Realtime 和 Volcengine WebSocket 握手加入取消进度回调；Realtime 增加 15 秒总超时
- 三个 ASR easy handle 均启用 CURLOPT_NOSIGNAL，避免多线程进程级超时信号风险

## 验证
- 单测：session_worker_completion_test，覆盖立即完成、超时、异步完成
- Release 构建成功
- 在 Release 构建目录执行 cpack -G DEB 成功

说明：curl 使用同步 DNS resolver 时，启用 NOSIGNAL 后 DNS 阶段不受 timeout 约束；这是 libcurl 官方建议的多线程安全取舍。