### PR TITLE
chore(ci): cabbage.yml actions 对齐 Node 24

### DIFF
--- a/.github/workflows/cabbage.yml
+++ b/.github/workflows/cabbage.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -53,12 +53,12 @@ jobs:
           python -m cabbage_cli ci --base origin/${{ github.base_ref }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'pnpm'
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -89,4 +89,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
消除 Node 20 deprecation 警告：actions/checkout@v4→v7、setup-python@v5→v7、setup-node@v4→v7、pnpm/action-setup@v4→v6、upload-pages-artifact@v3→v5、deploy-pages@v4→v5（其余 workflow 已是最新）